### PR TITLE
feat: テスト向けのモック機能の追加

### DIFF
--- a/.changeset/add-mock-and-bug-fixes.md
+++ b/.changeset/add-mock-and-bug-fixes.md
@@ -1,0 +1,22 @@
+---
+"routopia": minor
+---
+
+Add mocking support and improve URL processing reliability
+
+**New Features:**
+- Mocking Support: Added a new `.mock()` method for each route and HTTP method. It automatically replaces missing path parameters with `*` and relaxes type constraints, making it easier to define URLs for mock servers like MSW.
+
+```ts
+const myRoutes = routes({ "/users/[id]": { params: { id: type as string } } });
+myRoutes["/users/[id]"].mock(); // => "/users/*"
+myRoutes["/users/[id]"].mock({ params: { id: "123" } }); // => "/users/123"
+```
+
+**Bug Fixes:**
+- Empty Query Parameters: Fixed an issue where an empty queries object would still append a trailing `?` to the generated URL.
+
+**Improvements:**
+- URL Scheme Handling: Refined URL scheme handling using regular expressions. This ensures that complex URLs, such as those with multiple schemes (e.g., `myapp://https://example.com`), are processed safely without breaking their structure.
+- Internal Optimization: Removed redundant utilities and type definitions to simplify the codebase.
+- Enhanced Test Coverage: Significantly expanded the test suite, including new unit tests and type-level tests (dts), to ensure reliability and prevent regressions across various URL patterns and edge cases.

--- a/README.ja.md
+++ b/README.ja.md
@@ -106,6 +106,7 @@ routopia は宣言的で型安全な簡素な URL の取得に焦点を当てて
 - [Base URL](#base-url)
 - [Shorthand](#shorthand)
 - [Best Practice](#best-practice)
+- [Testing](#testing)
 
 ### No Parameters
 
@@ -135,8 +136,8 @@ myRoutes["/path"].delete();
 - `[param]` のように `[]` で囲む
 - 複数のパスパラメータも指定可能
 - パスパラメータは `params` オブジェクト内で定義
-- パスパラメータの型は専用の `type` オブジェクトを利用して型アサーション(`type as 型` もしくは `<型>type`)を使って型を指定
 - パスパラメータの型は `string | number` を満たす指定が可能
+- パラメータの型は専用の `type` オブジェクトを利用して型アサーション(`type as 型` もしくは `<型>type`)を使って指定する(以降の他パラメータも同様の型指定方法)
 
 ```ts
 import { routes, type } from 'routopia';
@@ -227,6 +228,7 @@ myRoutes["/path/[[...slug]]"].get();
 
 - クエリパラメータは `queries` オブジェクト内で定義
 - クエリパラメータは `object` 以外の型を指定可能
+  - `string`, `number`, `boolean`, 配列など
 - `undefined` を含めて指定することでオプショナル(省略可能)にできる
 
 ```ts
@@ -509,3 +511,115 @@ postRoutes["/posts/[id]"].get({ params: { id: 123 } });
 > // すべてのルートを一律で検索できるが、バンドルサイズは増大する
 > ```
 > </details>
+
+### Testing
+
+MSW などのモックサーバーを利用する際も、テスト用の URL を組み立てるために `routopia` をそのまま流用することができます。  
+テスト向けの柔軟な URL 構築のために、**定義した各パラメータの型制約を緩めた特別な `mock` メソッドを提供**しています。
+
+- `mock` メソッドは、各エンドポイント直下と各 HTTP メソッド定義の直下から呼び出すことが可能
+- エンドポイント直下の `mock` メソッドの引数は、すべての HTTP メソッド定義のパラメータを引き継ぐ
+- HTTP メソッド直下の `mock` メソッドの引数は、その HTTP メソッド定義のパラメータのみを引き継ぐ
+- `mock` メソッドの引数である各パラメータに指定できる型は、定義時に指定できる範囲と同じになる
+  - [パスパラメータは `string` | `number` を満たす値](#path-parameters)
+  - [可変長なパスパラメータは `string[] | number[]` を満たす値](#catch-all-parameters)
+  - [クエリパラメータは `object` 以外を満たす値](#query-parameters)
+  - [ハッシュパラメータは `string` を満たす値](#hash)
+- `mock` メソッドの引数はすべて省略可能
+  - なおパスパラメータの指定を省略した場合は、`*` が自動的に設定される
+
+```ts
+import { routes, type } from 'routopia';
+
+const myRoutes = routes({
+  "/path/[num]": {
+    params: { num: type as number },
+    queries: {
+      req: type as string,
+      opt: type as number | undefined
+    }
+  }
+});
+
+myRoutes["/path/[num]"].mock()
+myRoutes["/path/[num]"].get.mock()
+// => "/path/*"
+
+myRoutes["/path/[num]"].mock({ params: { num: "abc" }, queries: { opt: "q" } })
+myRoutes["/path/[num]"].get.mock({ params: { num: "abc" }, queries: { opt: "q" } })
+// => "/path/abc?opt=q"
+
+Parameters<(typeof myRoutes)["/path/[num]"]["mock"]>
+Parameters<(typeof myRoutes)["/path/[num]"]["get"]["mock"]>
+// ^? [{
+//   params?: { num?: string | number } };
+//   queries?: {
+//     req?: string | number | boolean | string[]...;
+//     opt?: string | number | boolean | string[]...;
+//   };
+// }]
+```
+
+<details>
+<summary>More Examples</summary>
+
+```ts
+import { routes, type } from 'routopia';
+
+const myRoutes = routes({
+  "/path/[...strArr]": {
+    params: { strArr: type as string[] }
+  }
+});
+
+Parameters<(typeof myRoutes)["/path/[...strArr]"]["mock"]>
+Parameters<(typeof myRoutes)["/path/[...strArr]"]["get"]["mock"]>
+// ^? [{ params?: { strArr?: string[] | number[] } }]
+```
+
+```ts
+import { routes, type } from 'routopia';
+
+const myRoutes = routes({
+  "/path": {
+    get: {
+      queries: {
+        a: type as string,
+        b: type as string
+      }
+    },
+    post: {
+      queries: {
+        b: type as number,
+        c: type as number
+      }
+    }
+  }
+});
+
+Parameters<(typeof myRoutes)["/path"]["mock"]>
+// ^? [{
+//   queries?: {
+//     a?: string | number | boolean | string[]...;
+//     b?: string | number | boolean | string[]...;
+//     c?: string | number | boolean | string[]...;
+//   }
+// }]
+
+Parameters<(typeof myRoutes)["/path"]["get"]["mock"]>
+// ^? [{
+//   queries?: {
+//     a?: string | number | boolean | string[]...;
+//     b?: string | number | boolean | string[]...;
+//   }
+// }]
+
+Parameters<(typeof myRoutes)["/path"]["post"]["mock"]>
+// ^? [{
+//   queries?: {
+//     b?: string | number | boolean | string[]...;
+//     c?: string | number | boolean | string[]...;
+//   }
+// }]
+```
+</details>

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ myRoutes["/path/[id]"].get({ params: { id: 123 }, queries: { q: "query" }  });
 // => "/path/123?q=query"
 ```
 
-> [!TIP]  
+> [!TIP]
 > The return value is inferred in detail by template literal types.  
 > For example, if `const path = myRoutes["/users"].get()`, the type of path will be `"/users"`.  
 > If you want to receive it as a string type, please add a type annotation:  
@@ -107,7 +107,8 @@ Conversely, routopia might be a good match for the following cases:
 - [Hash](#hash)
 - [Base URL](#base-url)
 - [Shorthand](#shorthand)
-- [Best Practices](#best-practices)
+- [Best Practice](#best-practice)
+- [Testing](#testing)
 
 ### No Parameters
 
@@ -137,8 +138,8 @@ myRoutes["/path"].delete();
 - Enclose with `[]` like `[param]`.
 - Multiple path parameters can also be specified.
 - Path parameters are defined within the `params` object.
-- Specify the `type` of path parameters using type assertion (`type as {Type}` or `<{Type}>type`) with the dedicated type object.
 - The type of path parameters can be specified satisfying `string | number`.
+- Specify the `type` of path parameters using type assertion (`type as {Type}` or `<{Type}>type`) with the dedicated type object (the same applies to other parameters).
 
 ```ts
 import { routes, type } from 'routopia';
@@ -230,6 +231,7 @@ myRoutes["/path/[[...slug]]"].get();
 
 - Query parameters are defined within the `queries` object.
 - Types other than `object` can be specified for query parameters.
+  - `string`, `number`, `boolean`, arrays, etc.
 - Including `undefined` makes them optional (omittable).
 
 ```ts
@@ -386,7 +388,7 @@ myRoutes["/short/[param]"].get({
 > While it's possible to use them together across different endpoints, you should split definition files to prevent notation inconsistencies within the same domain.
 > 
 > <details>
-> <summary>Examples of Mixing HTTP method definitions and Shorthand</summary>
+ > <summary>Examples of combining HTTP method definitions and Shorthand</summary>
 > 
 > ```ts
 > import { routes, empty, type } from 'routopia';
@@ -426,7 +428,7 @@ myRoutes["/short/[param]"].get({
 > ```
 > </details>
 
-### Best Practices
+### Best Practice
 
 - Create an abstraction layer by wrapping `routopia`.
 - It's also possible to specify the Base URL collectively.
@@ -478,7 +480,7 @@ export const postRoutes = createMyApiRoutes({
 ```
 
 ```ts
-// Example Usage
+// Usage
 import { userRoutes } from './path/to/userRoutes';
 import { postRoutes } from './path/to/postRoutes';
 
@@ -505,10 +507,123 @@ postRoutes["/posts/[id]"].get({ params: { id: 123 } });
 >   ...postRoutes,
 > };
 > 
-> // Example Usage
+> // Usage
 > import { apiRoutes } from './path/to/index';
 > apiRoutes["/users"].get();
 > apiRoutes["/posts/[id]"].get({ params: { id: 123 } });
 > // You can search all routes uniformly, but the bundle size will increase
 > ```
 > </details>
+
+### Testing
+
+When using mock servers such as MSW, you can use `routopia` as-is to build URLs for testing.  
+For flexible URL construction in tests, **a special `mock` method is provided that relaxes the type constraints of each defined parameter**.
+
+- The `mock` method can be called directly under each endpoint and under each HTTP method definition.
+- The `mock` method directly under an endpoint inherits parameters from all HTTP method definitions.
+- The `mock` method under an HTTP method inherits only that HTTP method's parameters.
+- The types that can be specified for each parameter in the `mock` method's arguments are the same range as those available during definition:
+  - [Path parameters accept values satisfying `string` | `number`](#path-parameters)
+  - [Catch-all parameters accept values satisfying `string[] | number[]`](#catch-all-parameters)
+  - [Query parameters accept values satisfying anything other than `object`](#query-parameters)
+  - [Hash parameters accept values satisfying `string`](#hash)
+- All arguments of the `mock` method are optional.
+  - If path parameter specification is omitted, `*` is automatically set.
+
+```ts
+import { routes, type } from 'routopia';
+
+const myRoutes = routes({
+  "/path/[num]": {
+    params: { num: type as number },
+    queries: {
+      req: type as string,
+      opt: type as number | undefined
+    }
+  }
+});
+
+myRoutes["/path/[num]"].mock()
+myRoutes["/path/[num]"].get.mock()
+// => "/path/*"
+
+myRoutes["/path/[num]"].mock({ params: { num: "abc" }, queries: { opt: "q" } })
+myRoutes["/path/[num]"].get.mock({ params: { num: "abc" }, queries: { opt: "q" } })
+// => "/path/abc?opt=q"
+
+Parameters<(typeof myRoutes)["/path/[num]"]["mock"]>
+Parameters<(typeof myRoutes)["/path/[num]"]["get"]["mock"]>
+// ^? [{
+//   params?: { num?: string | number } };
+//   queries?: {
+//     req?: string | number | boolean | string[]...;
+//     opt?: string | number | boolean | string[]...;
+//   };
+// }]
+```
+
+<details>
+<summary>More Examples</summary>
+
+```ts
+import { routes, type } from 'routopia';
+
+const myRoutes = routes({
+  "/path/[...strArr]": {
+    params: { strArr: type as string[] }
+  }
+});
+
+Parameters<(typeof myRoutes)["/path/[...strArr]"]["mock"]>
+Parameters<(typeof myRoutes)["/path/[...strArr]"]["get"]["mock"]>
+// ^? [{ params?: { strArr?: string[] | number[] } }]
+```
+
+```ts
+import { routes, type } from 'routopia';
+
+const myRoutes = routes({
+  "/path": {
+    get: {
+      queries: {
+        a: type as string,
+        b: type as string
+      }
+    },
+    post: {
+      queries: {
+        b: type as number,
+        c: type as number
+      }
+    }
+  }
+});
+
+Parameters<(typeof myRoutes)["/path"]["mock"]>
+// ^? [{
+//   queries?: {
+//     a?: string | number | boolean | string[]...;
+//     b?: string | number | boolean | string[]...;
+//     c?: string | number | boolean | string[]...;
+//   }
+// }]
+
+Parameters<(typeof myRoutes)["/path"]["get"]["mock"]>
+// ^? [{
+//   queries?: {
+//     a?: string | number | boolean | string[]...;
+//     b?: string | number | boolean | string[]...;
+//   }
+// }]
+
+Parameters<(typeof myRoutes)["/path"]["post"]["mock"]>
+// ^? [{
+//   queries?: {
+//     b?: string | number | boolean | string[]...;
+//     c?: string | number | boolean | string[]...;
+//   }
+// }]
+```
+</details>
+

--- a/src/definitions.test-d.ts
+++ b/src/definitions.test-d.ts
@@ -1,4 +1,6 @@
+import { expectTypeOf } from "vitest";
 import schema from ".";
+import type { SchemaArrayParam, SchemaPrimitiveParam, SchemaQuery } from "./types";
 
 describe("routes", () => {
   /**
@@ -323,12 +325,22 @@ describe("routes", () => {
         "/short": schema.empty,
       });
 
-      it("引数の型がないこと", () => {
+      it("引数が要求されないこと", () => {
         expectTypeOf(routes["/methods"].get).parameters.toEqualTypeOf<[]>();
         expectTypeOf(routes["/methods"].post).parameters.toEqualTypeOf<[]>();
         expectTypeOf(routes["/methods"].put).parameters.toEqualTypeOf<[]>();
         expectTypeOf(routes["/methods"].delete).parameters.toEqualTypeOf<[]>();
         expectTypeOf(routes["/short"].get).parameters.toEqualTypeOf<[]>();
+      });
+
+      it("mock 関数も引数が要求されないこと", () => {
+        expectTypeOf(routes["/methods"].mock).parameters.toEqualTypeOf<[]>();
+        expectTypeOf(routes["/methods"].get.mock).parameters.toEqualTypeOf<[]>();
+        expectTypeOf(routes["/methods"].post.mock).parameters.toEqualTypeOf<[]>();
+        expectTypeOf(routes["/methods"].put.mock).parameters.toEqualTypeOf<[]>();
+        expectTypeOf(routes["/methods"].delete.mock).parameters.toEqualTypeOf<[]>();
+        expectTypeOf(routes["/short"].mock).parameters.toEqualTypeOf<[]>();
+        expectTypeOf(routes["/short"].get.mock).parameters.toEqualTypeOf<[]>();
       });
 
       it("戻り値が詳細に推論されること", () => {
@@ -337,6 +349,16 @@ describe("routes", () => {
         expectTypeOf(routes["/methods"].put()).toEqualTypeOf<"/methods">();
         expectTypeOf(routes["/methods"].delete()).toEqualTypeOf<"/methods">();
         expectTypeOf(routes["/short"].get()).toEqualTypeOf<"/short">();
+      });
+
+      it("mock 関数も戻り値が詳細に推論されること", () => {
+        expectTypeOf(routes["/methods"].mock()).toEqualTypeOf<"/methods">();
+        expectTypeOf(routes["/methods"].get.mock()).toEqualTypeOf<"/methods">();
+        expectTypeOf(routes["/methods"].post.mock()).toEqualTypeOf<"/methods">();
+        expectTypeOf(routes["/methods"].put.mock()).toEqualTypeOf<"/methods">();
+        expectTypeOf(routes["/methods"].delete.mock()).toEqualTypeOf<"/methods">();
+        expectTypeOf(routes["/short"].mock()).toEqualTypeOf<"/short">();
+        expectTypeOf(routes["/short"].get.mock()).toEqualTypeOf<"/short">();
       });
     });
 
@@ -357,27 +379,68 @@ describe("routes", () => {
       });
 
       it("引数が要求されること", () => {
-        expectTypeOf(routes["/methods/[param]"].get).parameters.branded.toEqualTypeOf<
-          [{ params: { param: string } }]
-        >();
+        type ExpectedType = [{ params: { param: string } }];
 
-        expectTypeOf(routes["/short/[param]"].get).parameters.branded.toEqualTypeOf<[{ params: { param: string } }]>();
+        expectTypeOf(routes["/methods/[param]"].get).parameters.branded.toEqualTypeOf<ExpectedType>();
+        expectTypeOf(routes["/short/[param]"].get).parameters.branded.toEqualTypeOf<ExpectedType>();
+      });
+
+      it("mock 関数では引数が省略でき、パラメータの型が緩いこと", () => {
+        type ExpectedType = [{ params?: { param?: SchemaPrimitiveParam } }?];
+
+        // expectTypeOf(routes["/methods/[params]"].mock).parameters.branded.toEqualTypeOf の形式だと何故かテストが通らない
+        expectTypeOf<Parameters<(typeof routes)["/methods/[param]"]["mock"]>>().toEqualTypeOf<ExpectedType>();
+        expectTypeOf<Parameters<(typeof routes)["/methods/[param]"]["get"]["mock"]>>().toEqualTypeOf<ExpectedType>();
+
+        expectTypeOf<Parameters<(typeof routes)["/short/[param]"]["mock"]>>().toEqualTypeOf<ExpectedType>();
+        expectTypeOf<Parameters<(typeof routes)["/short/[param]"]["get"]["mock"]>>().toEqualTypeOf<ExpectedType>();
       });
 
       it("戻り値が詳細に推論されること", () => {
-        expectTypeOf(
-          routes["/methods/[param]"].get({ params: { param: "value" } }),
-        ).toEqualTypeOf<`/methods/${string}`>();
+        const options1 = { params: { param: "value" } };
 
-        expectTypeOf(routes["/short/[param]"].get({ params: { param: "value" } })).toEqualTypeOf<`/short/${string}`>();
+        expectTypeOf(routes["/methods/[param]"].get(options1)).toEqualTypeOf<`/methods/${string}`>();
+        expectTypeOf(routes["/short/[param]"].get(options1)).toEqualTypeOf<`/short/${string}`>();
 
-        expectTypeOf(
-          routes["/methods/[param]"].get({ params: { param: "value" } } as const),
-        ).toEqualTypeOf<"/methods/value">();
+        const options2 = { params: { param: "value" } } as const;
 
-        expectTypeOf(
-          routes["/short/[param]"].get({ params: { param: "value" } } as const),
-        ).toEqualTypeOf<"/short/value">();
+        expectTypeOf(routes["/methods/[param]"].get(options2)).toEqualTypeOf<"/methods/value">();
+        expectTypeOf(routes["/short/[param]"].get(options2)).toEqualTypeOf<"/short/value">();
+      });
+
+      it("mock 関数も戻り値が詳細に推論されること", () => {
+        expectTypeOf(routes["/methods/[param]"].mock()).toEqualTypeOf<"/methods/*">();
+        expectTypeOf(routes["/methods/[param]"].get.mock()).toEqualTypeOf<"/methods/*">();
+        expectTypeOf(routes["/short/[param]"].mock()).toEqualTypeOf<"/short/*">();
+        expectTypeOf(routes["/short/[param]"].get.mock()).toEqualTypeOf<"/short/*">();
+
+        const options1 = { params: { param: "value" } };
+
+        expectTypeOf(routes["/methods/[param]"].mock(options1)).toEqualTypeOf<`/methods/${string}`>();
+        expectTypeOf(routes["/methods/[param]"].get.mock(options1)).toEqualTypeOf<`/methods/${string}`>();
+        expectTypeOf(routes["/short/[param]"].mock(options1)).toEqualTypeOf<`/short/${string}`>();
+        expectTypeOf(routes["/short/[param]"].get.mock(options1)).toEqualTypeOf<`/short/${string}`>();
+
+        const options2 = { params: { param: 123 } };
+
+        expectTypeOf(routes["/methods/[param]"].mock(options2)).toEqualTypeOf<`/methods/${number}`>();
+        expectTypeOf(routes["/methods/[param]"].get.mock(options2)).toEqualTypeOf<`/methods/${number}`>();
+        expectTypeOf(routes["/short/[param]"].mock(options2)).toEqualTypeOf<`/short/${number}`>();
+        expectTypeOf(routes["/short/[param]"].get.mock(options2)).toEqualTypeOf<`/short/${number}`>();
+
+        const options3 = { params: { param: "value" } } as const;
+
+        expectTypeOf(routes["/methods/[param]"].mock(options3)).toEqualTypeOf<"/methods/value">();
+        expectTypeOf(routes["/methods/[param]"].get.mock(options3)).toEqualTypeOf<"/methods/value">();
+        expectTypeOf(routes["/short/[param]"].mock(options3)).toEqualTypeOf<"/short/value">();
+        expectTypeOf(routes["/short/[param]"].get.mock(options3)).toEqualTypeOf<"/short/value">();
+
+        const options4 = { params: { param: 123 } } as const;
+
+        expectTypeOf(routes["/methods/[param]"].mock(options4)).toEqualTypeOf<"/methods/123">();
+        expectTypeOf(routes["/methods/[param]"].get.mock(options4)).toEqualTypeOf<"/methods/123">();
+        expectTypeOf(routes["/short/[param]"].mock(options4)).toEqualTypeOf<"/short/123">();
+        expectTypeOf(routes["/short/[param]"].get.mock(options4)).toEqualTypeOf<"/short/123">();
       });
     });
 
@@ -387,44 +450,85 @@ describe("routes", () => {
           get: {
             params: {
               param1: schema.type as string,
-              param2: schema.type as string,
+              param2: schema.type as number,
             },
           },
         },
         "/short/[param1]/[param2]": {
           params: {
             param1: schema.type as string,
-            param2: schema.type as string,
+            param2: schema.type as number,
           },
         },
       });
 
       it("引数が要求されること", () => {
-        expectTypeOf(routes["/methods/[param1]/[param2]"].get).parameters.branded.toEqualTypeOf<
-          [{ params: { param1: string; param2: string } }]
-        >();
+        type ExpectedType = [{ params: { param1: string; param2: number } }];
+        // expectTypeOf(routes["/methods/[params]"].get).parameters.branded.toEqualTypeOf の形式だと何故かテストが通らない
+        expectTypeOf<
+          Parameters<(typeof routes)["/methods/[param1]/[param2]"]["get"]>
+        >().branded.toEqualTypeOf<ExpectedType>();
 
-        expectTypeOf(routes["/short/[param1]/[param2]"].get).parameters.branded.toEqualTypeOf<
-          [{ params: { param1: string; param2: string } }]
-        >();
+        expectTypeOf<
+          Parameters<(typeof routes)["/short/[param1]/[param2]"]["get"]>
+        >().branded.toEqualTypeOf<ExpectedType>();
+      });
+
+      it("mock 関数では引数が省略でき、パラメータの型が緩いこと", () => {
+        type ExpectedType = [{ params?: { param1?: SchemaPrimitiveParam; param2?: SchemaPrimitiveParam } }?];
+
+        // expectTypeOf(routes["/methods/[params]"].mock).parameters.branded.toEqualTypeOf の形式だと何故かテストが通らない
+        expectTypeOf<Parameters<(typeof routes)["/methods/[param1]/[param2]"]["mock"]>>().toEqualTypeOf<ExpectedType>();
+        expectTypeOf<
+          Parameters<(typeof routes)["/methods/[param1]/[param2]"]["get"]["mock"]>
+        >().toEqualTypeOf<ExpectedType>();
+
+        expectTypeOf<Parameters<(typeof routes)["/short/[param1]/[param2]"]["mock"]>>().toEqualTypeOf<ExpectedType>();
+        expectTypeOf<
+          Parameters<(typeof routes)["/short/[param1]/[param2]"]["get"]["mock"]>
+        >().toEqualTypeOf<ExpectedType>();
       });
 
       it("戻り値が詳細に推論されること", () => {
-        expectTypeOf(
-          routes["/methods/[param1]/[param2]"].get({ params: { param1: "value1", param2: "value2" } }),
-        ).toEqualTypeOf<`/methods/${string}/${string}`>();
+        const options1 = { params: { param1: "value", param2: 123 } };
 
         expectTypeOf(
-          routes["/short/[param1]/[param2]"].get({ params: { param1: "value1", param2: "value2" } }),
-        ).toEqualTypeOf<`/short/${string}/${string}`>();
+          routes["/methods/[param1]/[param2]"].get(options1),
+        ).toEqualTypeOf<`/methods/${string}/${number}`>();
+        expectTypeOf(routes["/short/[param1]/[param2]"].get(options1)).toEqualTypeOf<`/short/${string}/${number}`>();
+
+        const options2 = { params: { param1: "value", param2: 123 } } as const;
+
+        expectTypeOf(routes["/methods/[param1]/[param2]"].get(options2)).toEqualTypeOf<"/methods/value/123">();
+        expectTypeOf(routes["/short/[param1]/[param2]"].get(options2)).toEqualTypeOf<"/short/value/123">();
+      });
+
+      it("mock 関数も戻り値が詳細に推論されること", () => {
+        expectTypeOf(routes["/methods/[param1]/[param2]"].mock()).toEqualTypeOf<"/methods/*/*">();
+        expectTypeOf(routes["/methods/[param1]/[param2]"].get.mock()).toEqualTypeOf<"/methods/*/*">();
+        expectTypeOf(routes["/short/[param1]/[param2]"].mock()).toEqualTypeOf<"/short/*/*">();
+        expectTypeOf(routes["/short/[param1]/[param2]"].get.mock()).toEqualTypeOf<"/short/*/*">();
+
+        const options1 = { params: { param1: "value", param2: 123 } };
+        const options2 = { params: { param1: "value", param2: 123 } } as const;
 
         expectTypeOf(
-          routes["/methods/[param1]/[param2]"].get({ params: { param1: "value1", param2: "value2" } } as const),
-        ).toEqualTypeOf<"/methods/value1/value2">();
-
+          routes["/methods/[param1]/[param2]"].mock(options1),
+        ).toEqualTypeOf<`/methods/${string}/${number}`>();
         expectTypeOf(
-          routes["/short/[param1]/[param2]"].get({ params: { param1: "value1", param2: "value2" } } as const),
-        ).toEqualTypeOf<"/short/value1/value2">();
+          routes["/methods/[param1]/[param2]"].get.mock(options1),
+        ).toEqualTypeOf<`/methods/${string}/${number}`>();
+
+        expectTypeOf(routes["/methods/[param1]/[param2]"].mock(options2)).toEqualTypeOf<"/methods/value/123">();
+        expectTypeOf(routes["/methods/[param1]/[param2]"].get.mock(options2)).toEqualTypeOf<"/methods/value/123">();
+
+        expectTypeOf(routes["/short/[param1]/[param2]"].mock(options1)).toEqualTypeOf<`/short/${string}/${number}`>();
+        expectTypeOf(
+          routes["/short/[param1]/[param2]"].get.mock(options1),
+        ).toEqualTypeOf<`/short/${string}/${number}`>();
+
+        expectTypeOf(routes["/short/[param1]/[param2]"].mock(options2)).toEqualTypeOf<"/short/value/123">();
+        expectTypeOf(routes["/short/[param1]/[param2]"].get.mock(options2)).toEqualTypeOf<"/short/value/123">();
       });
     });
 
@@ -445,31 +549,56 @@ describe("routes", () => {
       });
 
       it("引数が要求されること", () => {
-        expectTypeOf(routes["/methods/[...params]"].get).parameters.branded.toEqualTypeOf<
-          [{ params: { params: readonly string[] } }]
-        >();
+        type ExpectedType = [{ params: { params: Readonly<string[]> } }];
 
-        expectTypeOf(routes["/short/[...params]"].get).parameters.branded.toEqualTypeOf<
-          [{ params: { params: readonly string[] } }]
-        >();
+        expectTypeOf(routes["/methods/[...params]"].get).parameters.branded.toEqualTypeOf<ExpectedType>();
+        expectTypeOf(routes["/short/[...params]"].get).parameters.branded.toEqualTypeOf<ExpectedType>();
+      });
+
+      it("mock 関数では引数が省略でき、パラメータの型が緩いこと", () => {
+        type ExpectedType = [{ params?: { params?: SchemaArrayParam } }?];
+
+        // expectTypeOf(routes["/methods/[params]"].mock).parameters.branded.toEqualTypeOf の形式だと何故かテストが通らない
+        expectTypeOf<Parameters<(typeof routes)["/methods/[...params]"]["mock"]>>().toEqualTypeOf<ExpectedType>();
+        expectTypeOf<
+          Parameters<(typeof routes)["/methods/[...params]"]["get"]["mock"]>
+        >().toEqualTypeOf<ExpectedType>();
+
+        expectTypeOf<Parameters<(typeof routes)["/short/[...params]"]["mock"]>>().toEqualTypeOf<ExpectedType>();
+        expectTypeOf<Parameters<(typeof routes)["/short/[...params]"]["get"]["mock"]>>().toEqualTypeOf<ExpectedType>();
       });
 
       it("戻り値が詳細に推論されること", () => {
-        expectTypeOf(
-          routes["/methods/[...params]"].get({ params: { params: ["value1", "value2"] } }),
-        ).toEqualTypeOf<`/methods/${string}`>();
+        const options1 = { params: { params: ["value1", "value2"] } };
 
-        expectTypeOf(
-          routes["/short/[...params]"].get({ params: { params: ["value1", "value2"] } }),
-        ).toEqualTypeOf<`/short/${string}`>();
+        expectTypeOf(routes["/methods/[...params]"].get(options1)).toEqualTypeOf<`/methods/${string}`>();
+        expectTypeOf(routes["/short/[...params]"].get(options1)).toEqualTypeOf<`/short/${string}`>();
 
-        expectTypeOf(
-          routes["/methods/[...params]"].get({ params: { params: ["value1", "value2"] } } as const),
-        ).toEqualTypeOf<"/methods/value1/value2">();
+        const options2 = { params: { params: ["value1", "value2"] } } as const;
 
-        expectTypeOf(
-          routes["/short/[...params]"].get({ params: { params: ["value1", "value2"] } } as const),
-        ).toEqualTypeOf<"/short/value1/value2">();
+        expectTypeOf(routes["/methods/[...params]"].get(options2)).toEqualTypeOf<"/methods/value1/value2">();
+        expectTypeOf(routes["/short/[...params]"].get(options2)).toEqualTypeOf<"/short/value1/value2">();
+      });
+
+      it("mock 関数も戻り値が詳細に推論されること", () => {
+        expectTypeOf(routes["/methods/[...params]"].mock()).toEqualTypeOf<"/methods/*">();
+        expectTypeOf(routes["/methods/[...params]"].get.mock()).toEqualTypeOf<"/methods/*">();
+        expectTypeOf(routes["/short/[...params]"].mock()).toEqualTypeOf<"/short/*">();
+        expectTypeOf(routes["/short/[...params]"].get.mock()).toEqualTypeOf<"/short/*">();
+
+        const options1 = { params: { params: ["value", 123] } };
+
+        expectTypeOf(routes["/methods/[...params]"].mock(options1)).toEqualTypeOf<`/methods/${string | number}`>();
+        expectTypeOf(routes["/methods/[...params]"].get.mock(options1)).toEqualTypeOf<`/methods/${string | number}`>();
+        expectTypeOf(routes["/short/[...params]"].mock(options1)).toEqualTypeOf<`/short/${string | number}`>();
+        expectTypeOf(routes["/short/[...params]"].get.mock(options1)).toEqualTypeOf<`/short/${string | number}`>();
+
+        const options2 = { params: { params: ["value", 123] } } as const;
+
+        expectTypeOf(routes["/methods/[...params]"].mock(options2)).toEqualTypeOf<"/methods/value/123">();
+        expectTypeOf(routes["/methods/[...params]"].get.mock(options2)).toEqualTypeOf<"/methods/value/123">();
+        expectTypeOf(routes["/short/[...params]"].mock(options2)).toEqualTypeOf<"/short/value/123">();
+        expectTypeOf(routes["/short/[...params]"].get.mock(options2)).toEqualTypeOf<"/short/value/123">();
       });
     });
 
@@ -490,35 +619,68 @@ describe("routes", () => {
       });
 
       it("省略可能な引数が要求されること", () => {
-        // expectTypeOf(routes["/methods/[[...params]]"].get).parameters.branded.toEqualTypeOf の形式だと何故かテストが通らない
-        expectTypeOf<Parameters<(typeof routes)["/methods/[[...params]]"]["get"]>>().branded.toEqualTypeOf<
-          [{ params?: { params?: Readonly<string[]> } }?]
-        >();
+        type ExpectedType = [{ params?: { params?: Readonly<string[]> } }?];
 
-        expectTypeOf<Parameters<(typeof routes)["/short/[[...params]]"]["get"]>>().branded.toEqualTypeOf<
-          [{ params?: { params?: Readonly<string[]> } }?]
-        >();
+        // expectTypeOf(routes["/methods/[[...params]]"].get).parameters.branded.toEqualTypeOf の形式だと何故かテストが通らない
+        expectTypeOf<
+          Parameters<(typeof routes)["/methods/[[...params]]"]["get"]>
+        >().branded.toEqualTypeOf<ExpectedType>();
+        expectTypeOf<
+          Parameters<(typeof routes)["/short/[[...params]]"]["get"]>
+        >().branded.toEqualTypeOf<ExpectedType>();
+      });
+
+      it("mock 関数も引数が省略でき、パラメータの型が緩いこと", () => {
+        type ExpectedType = [{ params?: { params?: SchemaArrayParam } }?];
+
+        // expectTypeOf(routes["/methods/[[...params]]"].mock).parameters.branded.toEqualTypeOf の形式だと何故かテストが通らない
+        expectTypeOf<Parameters<(typeof routes)["/methods/[[...params]]"]["mock"]>>().toEqualTypeOf<ExpectedType>();
+        expectTypeOf<
+          Parameters<(typeof routes)["/methods/[[...params]]"]["get"]["mock"]>
+        >().toEqualTypeOf<ExpectedType>();
+
+        expectTypeOf<Parameters<(typeof routes)["/short/[[...params]]"]["mock"]>>().toEqualTypeOf<ExpectedType>();
+        expectTypeOf<
+          Parameters<(typeof routes)["/short/[[...params]]"]["get"]["mock"]>
+        >().toEqualTypeOf<ExpectedType>();
       });
 
       it("戻り値が詳細に推論されること", () => {
         expectTypeOf(routes["/methods/[[...params]]"].get()).toEqualTypeOf<"/methods">();
         expectTypeOf(routes["/short/[[...params]]"].get()).toEqualTypeOf<"/short">();
 
-        expectTypeOf(
-          routes["/methods/[[...params]]"].get({ params: { params: ["value1", "value2"] } }),
-        ).toEqualTypeOf<`/methods/${string}`>();
+        const options1 = { params: { params: ["value1", "value2"] } };
 
-        expectTypeOf(
-          routes["/short/[[...params]]"].get({ params: { params: ["value1", "value2"] } }),
-        ).toEqualTypeOf<`/short/${string}`>();
+        expectTypeOf(routes["/methods/[[...params]]"].get(options1)).toEqualTypeOf<`/methods/${string}`>();
+        expectTypeOf(routes["/short/[[...params]]"].get(options1)).toEqualTypeOf<`/short/${string}`>();
 
-        expectTypeOf(
-          routes["/methods/[[...params]]"].get({ params: { params: ["value1", "value2"] } } as const),
-        ).toEqualTypeOf<"/methods/value1/value2">();
+        const options2 = { params: { params: ["value1", "value2"] } } as const;
 
+        expectTypeOf(routes["/methods/[[...params]]"].get(options2)).toEqualTypeOf<"/methods/value1/value2">();
+        expectTypeOf(routes["/short/[[...params]]"].get(options2)).toEqualTypeOf<"/short/value1/value2">();
+      });
+
+      it("mock 関数も戻り値が詳細に推論されること", () => {
+        expectTypeOf(routes["/methods/[[...params]]"].mock()).toEqualTypeOf<"/methods/*">();
+        expectTypeOf(routes["/methods/[[...params]]"].get.mock()).toEqualTypeOf<"/methods/*">();
+        expectTypeOf(routes["/short/[[...params]]"].mock()).toEqualTypeOf<"/short/*">();
+        expectTypeOf(routes["/short/[[...params]]"].get.mock()).toEqualTypeOf<"/short/*">();
+
+        const options1 = { params: { params: ["value", 123] } };
+
+        expectTypeOf(routes["/methods/[[...params]]"].mock(options1)).toEqualTypeOf<`/methods/${string | number}`>();
+        expectTypeOf(routes["/short/[[...params]]"].mock(options1)).toEqualTypeOf<`/short/${string | number}`>();
         expectTypeOf(
-          routes["/short/[[...params]]"].get({ params: { params: ["value1", "value2"] } } as const),
-        ).toEqualTypeOf<"/short/value1/value2">();
+          routes["/methods/[[...params]]"].get.mock(options1),
+        ).toEqualTypeOf<`/methods/${string | number}`>();
+        expectTypeOf(routes["/short/[[...params]]"].get.mock(options1)).toEqualTypeOf<`/short/${string | number}`>();
+
+        const options2 = { params: { params: ["value", 123] } } as const;
+
+        expectTypeOf(routes["/methods/[[...params]]"].mock(options2)).toEqualTypeOf<"/methods/value/123">();
+        expectTypeOf(routes["/short/[[...params]]"].mock(options2)).toEqualTypeOf<"/short/value/123">();
+        expectTypeOf(routes["/methods/[[...params]]"].get.mock(options2)).toEqualTypeOf<"/methods/value/123">();
+        expectTypeOf(routes["/short/[[...params]]"].get.mock(options2)).toEqualTypeOf<"/short/value/123">();
       });
     });
 
@@ -552,11 +714,38 @@ describe("routes", () => {
         >();
       });
 
+      it("mock 関数では引数が省略でき、パラメータの型が緩いこと", () => {
+        type ExpectedType = [
+          {
+            queries?: {
+              string?: SchemaQuery;
+              number?: SchemaQuery;
+              boolean?: SchemaQuery;
+              array?: SchemaQuery;
+            };
+          }?,
+        ];
+
+        expectTypeOf(routes["/queries/required"].mock).parameters.branded.toEqualTypeOf<ExpectedType>();
+        expectTypeOf(routes["/queries/required"].get.mock).parameters.branded.toEqualTypeOf<ExpectedType>();
+      });
+
       it("戻り値が詳細に推論されること", () => {
         const result = routes["/queries/required"].get({
           queries: { string: "value", number: 1, boolean: true, array: ["a", "b"] },
         });
         expectTypeOf(result).toEqualTypeOf<`/queries/required?${string}`>();
+      });
+
+      it("mock 関数も戻り値が詳細に推論されること", () => {
+        type ExpectedType1 = `/queries/required${string}`;
+        expectTypeOf(routes["/queries/required"].mock()).toEqualTypeOf<ExpectedType1>();
+        expectTypeOf(routes["/queries/required"].get.mock()).toEqualTypeOf<ExpectedType1>();
+
+        type ExpectedType2 = `/queries/required?${string}`;
+        const options = { queries: { string: "value", number: 1, boolean: true, array: ["a", "b"] } };
+        expectTypeOf(routes["/queries/required"].mock(options)).toEqualTypeOf<ExpectedType2>();
+        expectTypeOf(routes["/queries/required"].get.mock(options)).toEqualTypeOf<ExpectedType2>();
       });
     });
 
@@ -589,6 +778,21 @@ describe("routes", () => {
         >();
       });
 
+      it("mock 関数も引数が省略でき、パラメータの型が緩いこと", () => {
+        type ExpectedType = [
+          {
+            queries?: {
+              string?: SchemaQuery;
+              number?: SchemaQuery;
+              boolean?: SchemaQuery;
+              array?: SchemaQuery;
+            };
+          }?,
+        ];
+        expectTypeOf(routes["/queries/optional"].mock).parameters.branded.toEqualTypeOf<ExpectedType>();
+        expectTypeOf(routes["/queries/optional"].get.mock).parameters.branded.toEqualTypeOf<ExpectedType>();
+      });
+
       it("戻り値が詳細に推論されること", () => {
         expectTypeOf(routes["/queries/optional"].get()).toEqualTypeOf<`/queries/optional${string}`>();
 
@@ -596,6 +800,17 @@ describe("routes", () => {
           queries: { string: "value", number: 1, boolean: true, array: ["a", "b"] },
         });
         expectTypeOf(result).toEqualTypeOf<`/queries/optional?${string}`>();
+      });
+
+      it("mock 関数も戻り値が詳細に推論されること", () => {
+        type ExpectedType1 = `/queries/optional${string}`;
+        expectTypeOf(routes["/queries/optional"].mock()).toEqualTypeOf<ExpectedType1>();
+        expectTypeOf(routes["/queries/optional"].get.mock()).toEqualTypeOf<ExpectedType1>();
+
+        type ExpectedType2 = `/queries/optional?${string}`;
+        const options = { queries: { string: "value", number: 1, boolean: true, array: ["a", "b"] } };
+        expectTypeOf(routes["/queries/optional"].mock(options)).toEqualTypeOf<ExpectedType2>();
+        expectTypeOf(routes["/queries/optional"].get.mock(options)).toEqualTypeOf<ExpectedType2>();
       });
     });
 
@@ -629,10 +844,36 @@ describe("routes", () => {
         >();
       });
 
+      it("mock 関数も引数が省略でき、パラメータの型が緩いこと", () => {
+        type ExpectedType = [
+          {
+            queries?: {
+              string?: SchemaQuery;
+              number?: SchemaQuery;
+              boolean?: SchemaQuery;
+              array?: SchemaQuery;
+            };
+          }?,
+        ];
+        expectTypeOf(routes["/queries/both"].mock).parameters.branded.toEqualTypeOf<ExpectedType>();
+        expectTypeOf(routes["/queries/both"].get.mock).parameters.branded.toEqualTypeOf<ExpectedType>();
+      });
+
       it("戻り値が詳細に推論されること", () => {
         expectTypeOf(
           routes["/queries/both"].get({ queries: { string: "value", number: 1 } }),
         ).toEqualTypeOf<`/queries/both?${string}`>();
+      });
+
+      it("mock 関数も戻り値が詳細に推論されること", () => {
+        type ExpectedType1 = `/queries/both${string}`;
+        expectTypeOf(routes["/queries/both"].mock()).toEqualTypeOf<ExpectedType1>();
+        expectTypeOf(routes["/queries/both"].get.mock()).toEqualTypeOf<ExpectedType1>();
+
+        type ExpectedType2 = `/queries/both?${string}`;
+        const options = { queries: { string: "value", number: 1 } };
+        expectTypeOf(routes["/queries/both"].mock(options)).toEqualTypeOf<ExpectedType2>();
+        expectTypeOf(routes["/queries/both"].get.mock(options)).toEqualTypeOf<ExpectedType2>();
       });
     });
 
@@ -640,23 +881,44 @@ describe("routes", () => {
       const routes = schema.routes({
         "/hash": {
           get: {
-            hash: schema.type as string,
+            hash: schema.type as "hash1" | "hash2",
           },
         },
       });
 
       it("省略可能な引数が要求されること", () => {
         // expectTypeOf(routes["/hash"].get).parameters.toEqualTypeOf の形式だと何故かテストが通らない;
-        expectTypeOf<Parameters<(typeof routes)["/hash"]["get"]>>().toEqualTypeOf<[{ hash?: string }?]>();
+        expectTypeOf<Parameters<(typeof routes)["/hash"]["get"]>>().toEqualTypeOf<[{ hash?: "hash1" | "hash2" }?]>();
+      });
+
+      it("mock 関数も引数が省略でき、パラメータの型が緩いこと", () => {
+        // expectTypeOf(routes["/hash"].mock).parameters.toEqualTypeOf の形式だと何故かテストが通らない;
+        type ExpectedType = [{ hash?: string }?];
+        expectTypeOf<Parameters<(typeof routes)["/hash"]["mock"]>>().toEqualTypeOf<ExpectedType>();
+        expectTypeOf<Parameters<(typeof routes)["/hash"]["get"]["mock"]>>().toEqualTypeOf<ExpectedType>();
       });
 
       it("戻り値が詳細に推論されること", () => {
         expectTypeOf(routes["/hash"].get()).toEqualTypeOf<"/hash">();
 
-        expectTypeOf(routes["/hash"].get({ hash: "section" })).toEqualTypeOf<`/hash#section`>();
+        expectTypeOf(routes["/hash"].get({ hash: "hash1" })).toEqualTypeOf<`/hash#hash1`>();
+        expectTypeOf(routes["/hash"].get({ hash: "hash2" })).toEqualTypeOf<`/hash#hash2`>();
+      });
 
-        const opt = { hash: "section" };
-        expectTypeOf(routes["/hash"].get(opt)).toEqualTypeOf<`/hash#${string}`>();
+      it("mock 関数も戻り値が詳細に推論されること", () => {
+        type ExpectedType1 = `/hash`;
+        expectTypeOf(routes["/hash"].mock()).toEqualTypeOf<ExpectedType1>();
+        expectTypeOf(routes["/hash"].get.mock()).toEqualTypeOf<ExpectedType1>();
+
+        type ExpectedType2 = `/hash#${string}`;
+        const options1 = { hash: "hash1" };
+        expectTypeOf(routes["/hash"].mock(options1)).toEqualTypeOf<ExpectedType2>();
+        expectTypeOf(routes["/hash"].get.mock(options1)).toEqualTypeOf<ExpectedType2>();
+
+        type ExpectedType3 = `/hash#hash1`;
+        const options2 = { hash: "hash1" } as const;
+        expectTypeOf(routes["/hash"].mock(options2)).toEqualTypeOf<ExpectedType3>();
+        expectTypeOf(routes["/hash"].get.mock(options2)).toEqualTypeOf<ExpectedType3>();
       });
     });
 
@@ -687,6 +949,18 @@ describe("routes", () => {
         >();
       });
 
+      it("mock 関数も引数が省略でき、パラメータの型が緩いこと", () => {
+        type ExpectedType = [
+          {
+            params?: { param?: SchemaPrimitiveParam };
+            queries?: { optional?: SchemaQuery };
+            hash?: string;
+          }?,
+        ];
+        expectTypeOf(routes["/all/[param]"].mock).parameters.branded.toEqualTypeOf<ExpectedType>();
+        expectTypeOf(routes["/all/[param]"].get.mock).parameters.branded.toEqualTypeOf<ExpectedType>();
+      });
+
       it("戻り値が詳細に推論されること", () => {
         expectTypeOf(
           routes["/all/[param]"].get({ params: { param: "value" }, hash: "section" } as const),
@@ -711,6 +985,30 @@ describe("routes", () => {
         };
         expectTypeOf(routes["/all/[param]"].get(opt)).toEqualTypeOf<`/all/${string}?${string}#${string}`>();
       });
+
+      it("mock 関数も戻り値が詳細に推論されること", () => {
+        type ExpectedType1 = `/all/*${string}`;
+        expectTypeOf(routes["/all/[param]"].mock()).toEqualTypeOf<ExpectedType1>();
+        expectTypeOf(routes["/all/[param]"].get.mock()).toEqualTypeOf<ExpectedType1>();
+
+        type ExpectedType2 = `/all/${string}?${string}#${string}`;
+        const options = {
+          params: { param: "value" },
+          queries: { optional: "opt" },
+          hash: "section",
+        };
+        expectTypeOf(routes["/all/[param]"].mock(options)).toEqualTypeOf<ExpectedType2>();
+        expectTypeOf(routes["/all/[param]"].get.mock(options)).toEqualTypeOf<ExpectedType2>();
+
+        type ExpectedType3 = `/all/value?${string}#section`;
+        const options2 = {
+          params: { param: "value" },
+          queries: { optional: "opt" },
+          hash: "section",
+        } as const;
+        expectTypeOf(routes["/all/[param]"].mock(options2)).toEqualTypeOf<ExpectedType3>();
+        expectTypeOf(routes["/all/[param]"].get.mock(options2)).toEqualTypeOf<ExpectedType3>();
+      });
     });
 
     describe("Base URL", () => {
@@ -720,6 +1018,12 @@ describe("routes", () => {
 
       it("戻り値が詳細に推論されること", () => {
         expectTypeOf(routes["/path"].get()).toEqualTypeOf<`https://api.example.com/path`>();
+      });
+
+      it("mock 関数も戻り値が詳細に推論されること", () => {
+        type ExpectedType = `https://api.example.com/path`;
+        expectTypeOf(routes["/path"].mock()).toEqualTypeOf<ExpectedType>();
+        expectTypeOf(routes["/path"].get.mock()).toEqualTypeOf<ExpectedType>();
       });
     });
 
@@ -743,6 +1047,451 @@ describe("routes", () => {
         expectTypeOf(
           routes["myapp://path/[param]"].get({ params: { param: "value" } } as const),
         ).toEqualTypeOf<`myapp://path/value`>();
+      });
+
+      it("mock 関数も戻り値が詳細に推論されること", () => {
+        type ExpectedType1 = `myapp://path`;
+        expectTypeOf(routes["myapp://path"].mock()).toEqualTypeOf<ExpectedType1>();
+        expectTypeOf(routes["myapp://path"].get.mock()).toEqualTypeOf<ExpectedType1>();
+      });
+    });
+
+    describe("Mock", () => {
+      const routes = schema.routes({
+        "/[param]": {
+          get: {
+            params: {
+              param: schema.type as string,
+            },
+            queries: {
+              a: schema.type as string,
+              x: schema.type as string,
+            },
+            hash: schema.type as "hash1",
+          },
+          post: {
+            params: {
+              param: schema.type as number,
+            },
+            queries: {
+              b: schema.type as number,
+              x: schema.type as number,
+            },
+            hash: schema.type as "hash2",
+          },
+        },
+        "/[...params]": {
+          get: {
+            params: {
+              params: schema.type as string[],
+            },
+          },
+          put: {
+            params: {
+              params: schema.type as number[],
+            },
+          },
+        },
+        "/[[...params]]": {
+          get: {
+            params: {
+              params: schema.type as string[],
+            },
+          },
+          delete: {
+            params: {
+              params: schema.type as number[],
+            },
+          },
+        },
+      });
+
+      it("トップレベルの mock 関数は各 HTTP メソッドを包括した引数を受けること", () => {
+        type ExpectedType1 = [
+          {
+            params?: { param?: SchemaPrimitiveParam };
+            queries?: { a?: SchemaQuery; b?: SchemaQuery; x?: SchemaQuery };
+            hash?: string;
+          }?,
+        ];
+        expectTypeOf(routes["/[param]"].mock).parameters.toEqualTypeOf<ExpectedType1>();
+
+        type ExpectedType2 = [
+          {
+            params?: { params?: SchemaArrayParam };
+          }?,
+        ];
+        expectTypeOf<Parameters<(typeof routes)["/[...params]"]["mock"]>>().toEqualTypeOf<ExpectedType2>();
+        expectTypeOf<Parameters<(typeof routes)["/[[...params]]"]["mock"]>>().toEqualTypeOf<ExpectedType2>();
+      });
+
+      it("トップレベルの mock 関数は HTTP メソッドが複数あっても戻り値が詳細に推論されること", () => {
+        expectTypeOf(routes["/[param]"].mock()).toEqualTypeOf<`/*${string}`>();
+        expectTypeOf(routes["/[...params]"].mock()).toEqualTypeOf<`/*`>();
+        expectTypeOf(routes["/[[...params]]"].mock()).toEqualTypeOf<`/*`>();
+
+        const options1 = { params: { param: "value" }, queries: { a: "a", b: "b" }, hash: "hash" };
+        expectTypeOf(routes["/[param]"].mock(options1)).toEqualTypeOf<`/${string}?${string}#${string}`>();
+
+        const options2 = { params: { param: "value" }, queries: { x: "x" }, hash: "hash" } as const;
+        expectTypeOf(routes["/[param]"].mock(options2)).toEqualTypeOf<`/value?${string}#hash`>();
+
+        const options3 = { params: { params: ["value1", "value2"] } };
+        expectTypeOf(routes["/[...params]"].mock(options3)).toEqualTypeOf<`/${string}`>();
+        expectTypeOf(routes["/[[...params]]"].mock(options3)).toEqualTypeOf<`/${string}`>();
+
+        const options4 = { params: { params: [123, 456] } } as const;
+        expectTypeOf(routes["/[...params]"].mock(options4)).toEqualTypeOf<`/123/456`>();
+        expectTypeOf(routes["/[[...params]]"].mock(options4)).toEqualTypeOf<`/123/456`>();
+      });
+
+      it("HTTP メソッドごとの mock 関数はそれぞれの定義を引き継いでおり、引数が省略でき、パラメータの型が緩いこと", () => {
+        type ExpectedType1 = [
+          { params?: { param?: SchemaPrimitiveParam }; queries?: { a?: SchemaQuery; x?: SchemaQuery }; hash?: string }?,
+        ];
+        expectTypeOf(routes["/[param]"].get.mock).parameters.toEqualTypeOf<ExpectedType1>();
+
+        type ExpectedType2 = [
+          { params?: { param?: SchemaPrimitiveParam }; queries?: { b?: SchemaQuery; x?: SchemaQuery }; hash?: string }?,
+        ];
+        expectTypeOf(routes["/[param]"].post.mock).parameters.toEqualTypeOf<ExpectedType2>();
+
+        type ExpectedType3 = [{ params?: { params?: SchemaArrayParam } }?];
+        expectTypeOf<Parameters<(typeof routes)["/[...params]"]["get"]["mock"]>>().toEqualTypeOf<ExpectedType3>();
+        expectTypeOf<Parameters<(typeof routes)["/[...params]"]["put"]["mock"]>>().toEqualTypeOf<ExpectedType3>();
+        expectTypeOf<Parameters<(typeof routes)["/[[...params]]"]["get"]["mock"]>>().toEqualTypeOf<ExpectedType3>();
+        expectTypeOf<Parameters<(typeof routes)["/[[...params]]"]["delete"]["mock"]>>().toEqualTypeOf<ExpectedType3>();
+      });
+
+      it("HTTP メソッドごとの mock 関数も戻り値が詳細に推論されること", () => {
+        type ExpectedType1 = `/*${string}`;
+        expectTypeOf(routes["/[param]"].get.mock()).toEqualTypeOf<ExpectedType1>();
+        expectTypeOf(routes["/[param]"].post.mock()).toEqualTypeOf<ExpectedType1>();
+
+        type ExpectedType2 = `/*`;
+        expectTypeOf(routes["/[...params]"].get.mock()).toEqualTypeOf<ExpectedType2>();
+        expectTypeOf(routes["/[...params]"].put.mock()).toEqualTypeOf<ExpectedType2>();
+        expectTypeOf(routes["/[[...params]]"].get.mock()).toEqualTypeOf<ExpectedType2>();
+        expectTypeOf(routes["/[[...params]]"].delete.mock()).toEqualTypeOf<ExpectedType2>();
+
+        const options1 = { params: { param: "value" }, queries: { a: "a", x: "x" }, hash: "hash" };
+        expectTypeOf(routes["/[param]"].get.mock(options1)).toEqualTypeOf<`/${string}?${string}#${string}`>();
+
+        const options2 = { params: { param: "value" }, queries: { b: "b", x: "x" }, hash: "hash" } as const;
+        expectTypeOf(routes["/[param]"].post.mock(options2)).toEqualTypeOf<`/value?${string}#hash`>();
+
+        const options3 = { params: { params: ["value1", "value2"] } };
+        expectTypeOf(routes["/[...params]"].get.mock(options3)).toEqualTypeOf<`/${string}`>();
+        expectTypeOf(routes["/[[...params]]"].get.mock(options3)).toEqualTypeOf<`/${string}`>();
+
+        const options4 = { params: { params: [123, 456] } } as const;
+        expectTypeOf(routes["/[...params]"].put.mock(options4)).toEqualTypeOf<`/123/456`>();
+        expectTypeOf(routes["/[[...params]]"].delete.mock(options4)).toEqualTypeOf<`/123/456`>();
+      });
+    });
+
+    describe("Base URL", () => {
+      const routes = schema.routes("https://api.example.com", {
+        "/path": {
+          get: schema.empty,
+          post: schema.empty,
+        },
+        "/path/[param]": {
+          get: {
+            params: {
+              param: schema.type as string,
+            },
+          },
+        },
+        "/path/[...params]": {
+          get: {
+            params: {
+              params: schema.type as string[],
+            },
+          },
+        },
+        "/path/[[...params]]": {
+          get: {
+            params: {
+              params: schema.type as string[],
+            },
+          },
+        },
+        "/path/all/[param]": {
+          get: {
+            params: {
+              param: schema.type as string,
+            },
+            queries: {
+              q: schema.type as string,
+            },
+            hash: schema.type as string,
+          },
+        },
+        "/short": schema.empty,
+        "/short/[param]": {
+          params: {
+            param: schema.type as string,
+          },
+        },
+        "/short/[...params]": {
+          params: {
+            params: schema.type as string[],
+          },
+        },
+        "/short/[[...params]]": {
+          params: {
+            params: schema.type as string[],
+          },
+        },
+        "/short/all/[param]": {
+          params: {
+            param: schema.type as string,
+          },
+          queries: {
+            q: schema.type as string,
+          },
+          hash: schema.type as string,
+        },
+      });
+
+      it("Base URL を含んで戻り値が詳細に推論されること", () => {
+        type ExpectedType1 = `https://api.example.com/path`;
+        expectTypeOf(routes["/path"].get()).toEqualTypeOf<ExpectedType1>();
+        expectTypeOf(routes["/path/[[...params]]"].get()).toEqualTypeOf<ExpectedType1>();
+
+        type ExpectedType2 = `https://api.example.com/path/${string}`;
+        const options1 = { params: { param: "value" } };
+        expectTypeOf(routes["/path/[param]"].get(options1)).toEqualTypeOf<ExpectedType2>();
+
+        const options2 = { params: { params: ["value1", "value2"] } };
+        expectTypeOf(routes["/path/[...params]"].get(options2)).toEqualTypeOf<ExpectedType2>();
+        expectTypeOf(routes["/path/[[...params]]"].get(options2)).toEqualTypeOf<ExpectedType2>();
+
+        const options3 = {
+          params: { param: "value" },
+          queries: { q: "query" },
+          hash: "hash",
+        } as const;
+        type ExpectedType3 = `https://api.example.com/path/all/value?${string}#hash`;
+        expectTypeOf(routes["/path/all/[param]"].get(options3)).toEqualTypeOf<ExpectedType3>();
+
+        type ExpectedType4 = `https://api.example.com/short`;
+        expectTypeOf(routes["/short"].get()).toEqualTypeOf<ExpectedType4>();
+        expectTypeOf(routes["/short/[[...params]]"].get()).toEqualTypeOf<ExpectedType4>();
+
+        type ExpectedType5 = `https://api.example.com/short/${string}`;
+        const options4 = { params: { param: "value" } };
+        expectTypeOf(routes["/short/[param]"].get(options4)).toEqualTypeOf<ExpectedType5>();
+
+        const options5 = { params: { params: ["value1", "value2"] } };
+        expectTypeOf(routes["/short/[...params]"].get(options5)).toEqualTypeOf<ExpectedType5>();
+        expectTypeOf(routes["/short/[[...params]]"].get(options5)).toEqualTypeOf<ExpectedType5>();
+
+        const options6 = {
+          params: { param: "value" },
+          queries: { q: "query" },
+          hash: "hash",
+        } as const;
+        type ExpectedType6 = `https://api.example.com/short/all/value?${string}#hash`;
+        expectTypeOf(routes["/short/all/[param]"].get(options6)).toEqualTypeOf<ExpectedType6>();
+      });
+
+      it("Base URL を含んで mock 関数も戻り値が詳細に推論されること", () => {
+        type ExpectedType1 = `https://api.example.com/path`;
+        expectTypeOf(routes["/path"].mock()).toEqualTypeOf<ExpectedType1>();
+        expectTypeOf(routes["/path"].get.mock()).toEqualTypeOf<ExpectedType1>();
+
+        type ExpectedType2 = `https://api.example.com/path/*`;
+        expectTypeOf(routes["/path/[param]"].mock()).toEqualTypeOf<ExpectedType2>();
+        expectTypeOf(routes["/path/[param]"].get.mock()).toEqualTypeOf<ExpectedType2>();
+        expectTypeOf(routes["/path/[...params]"].mock()).toEqualTypeOf<ExpectedType2>();
+        expectTypeOf(routes["/path/[...params]"].get.mock()).toEqualTypeOf<ExpectedType2>();
+        expectTypeOf(routes["/path/[[...params]]"].mock()).toEqualTypeOf<ExpectedType2>();
+        expectTypeOf(routes["/path/[[...params]]"].get.mock()).toEqualTypeOf<ExpectedType2>();
+
+        const options1 = { params: { param: "value" } };
+        type ExpectedType3 = `https://api.example.com/path/${string}`;
+        expectTypeOf(routes["/path/[param]"].mock(options1)).toEqualTypeOf<ExpectedType3>();
+        expectTypeOf(routes["/path/[param]"].get.mock(options1)).toEqualTypeOf<ExpectedType3>();
+
+        const options2 = { params: { params: ["value1", "value2"] } };
+        expectTypeOf(routes["/path/[...params]"].mock(options2)).toEqualTypeOf<ExpectedType3>();
+        expectTypeOf(routes["/path/[...params]"].get.mock(options2)).toEqualTypeOf<ExpectedType3>();
+        expectTypeOf(routes["/path/[[...params]]"].mock(options2)).toEqualTypeOf<ExpectedType3>();
+        expectTypeOf(routes["/path/[[...params]]"].get.mock(options2)).toEqualTypeOf<ExpectedType3>();
+
+        const options3 = { params: { param: "value" } } as const;
+        type ExpectedType4 = `https://api.example.com/path/value`;
+        expectTypeOf(routes["/path/[param]"].mock(options3)).toEqualTypeOf<ExpectedType4>();
+        expectTypeOf(routes["/path/[param]"].get.mock(options3)).toEqualTypeOf<ExpectedType4>();
+
+        const options4 = { params: { params: ["value1", "value2"] } } as const;
+        type ExpectedType5 = `https://api.example.com/path/value1/value2`;
+        expectTypeOf(routes["/path/[...params]"].mock(options4)).toEqualTypeOf<ExpectedType5>();
+        expectTypeOf(routes["/path/[...params]"].get.mock(options4)).toEqualTypeOf<ExpectedType5>();
+        expectTypeOf(routes["/path/[[...params]]"].mock(options4)).toEqualTypeOf<ExpectedType5>();
+        expectTypeOf(routes["/path/[[...params]]"].get.mock(options4)).toEqualTypeOf<ExpectedType5>();
+
+        const options5 = {
+          params: { param: "value" },
+          queries: { q: "query" },
+          hash: "hash",
+        };
+        type ExpectedType6 = `https://api.example.com/path/all/${string}?${string}#${string}`;
+        expectTypeOf(routes["/path/all/[param]"].mock(options5)).toEqualTypeOf<ExpectedType6>();
+        expectTypeOf(routes["/path/all/[param]"].get.mock(options5)).toEqualTypeOf<ExpectedType6>();
+
+        const options6 = {
+          params: { param: "value" },
+          queries: { q: "query" },
+          hash: "hash",
+        } as const;
+        type ExpectedType7 = `https://api.example.com/path/all/value?${string}#hash`;
+        expectTypeOf(routes["/path/all/[param]"].mock(options6)).toEqualTypeOf<ExpectedType7>();
+        expectTypeOf(routes["/path/all/[param]"].get.mock(options6)).toEqualTypeOf<ExpectedType7>();
+
+        type ExpectedType8 = `https://api.example.com/short`;
+        expectTypeOf(routes["/short"].mock()).toEqualTypeOf<ExpectedType8>();
+        expectTypeOf(routes["/short"].get.mock()).toEqualTypeOf<ExpectedType8>();
+
+        type ExpectedType9 = `https://api.example.com/short/*`;
+        expectTypeOf(routes["/short/[param]"].mock()).toEqualTypeOf<ExpectedType9>();
+        expectTypeOf(routes["/short/[param]"].get.mock()).toEqualTypeOf<ExpectedType9>();
+        expectTypeOf(routes["/short/[...params]"].mock()).toEqualTypeOf<ExpectedType9>();
+        expectTypeOf(routes["/short/[...params]"].get.mock()).toEqualTypeOf<ExpectedType9>();
+        expectTypeOf(routes["/short/[[...params]]"].mock()).toEqualTypeOf<ExpectedType9>();
+        expectTypeOf(routes["/short/[[...params]]"].get.mock()).toEqualTypeOf<ExpectedType9>();
+
+        const options7 = { params: { param: "value" } };
+        type ExpectedType10 = `https://api.example.com/short/${string}`;
+        expectTypeOf(routes["/short/[param]"].mock(options7)).toEqualTypeOf<ExpectedType10>();
+        expectTypeOf(routes["/short/[param]"].get.mock(options7)).toEqualTypeOf<ExpectedType10>();
+
+        const options8 = { params: { params: ["value1", "value2"] } };
+        expectTypeOf(routes["/short/[...params]"].mock(options8)).toEqualTypeOf<ExpectedType10>();
+        expectTypeOf(routes["/short/[...params]"].get.mock(options8)).toEqualTypeOf<ExpectedType10>();
+        expectTypeOf(routes["/short/[[...params]]"].mock(options8)).toEqualTypeOf<ExpectedType10>();
+        expectTypeOf(routes["/short/[[...params]]"].get.mock(options8)).toEqualTypeOf<ExpectedType10>();
+
+        const options9 = {
+          params: { param: "value" },
+          queries: { q: "query" },
+          hash: "hash",
+        };
+        type ExpectedType11 = `https://api.example.com/short/all/${string}?${string}#${string}`;
+        expectTypeOf(routes["/short/all/[param]"].mock(options9)).toEqualTypeOf<ExpectedType11>();
+        expectTypeOf(routes["/short/all/[param]"].get.mock(options9)).toEqualTypeOf<ExpectedType11>();
+
+        const options10 = {
+          params: { param: "value" },
+          queries: { q: "query" },
+          hash: "hash",
+        } as const;
+        type ExpectedType12 = `https://api.example.com/short/all/value?${string}#hash`;
+        expectTypeOf(routes["/short/all/[param]"].mock(options10)).toEqualTypeOf<ExpectedType12>();
+        expectTypeOf(routes["/short/all/[param]"].get.mock(options10)).toEqualTypeOf<ExpectedType12>();
+      });
+    });
+
+    describe("Custom Schema", () => {
+      const routes = schema.routes({
+        "myapp://path": schema.empty,
+        "myapp://path/[param]": {
+          params: {
+            param: schema.type as string,
+          },
+        },
+        "myapp://path/[...params]": {
+          params: {
+            params: schema.type as string[],
+          },
+        },
+        "myapp://path/[[...params]]": {
+          params: {
+            params: schema.type as string[],
+          },
+        },
+        "myapp://https://example.com/[param]": {
+          params: {
+            param: schema.type as string,
+          },
+        },
+        "myapp://path/[[...params]]/https://example.com/[param]": {
+          params: {
+            params: schema.type as string[],
+            param: schema.type as string,
+          },
+        },
+      });
+
+      it("Custom Schema を含んで戻り値が詳細に推論されること", () => {
+        type ExpectedType1 = `myapp://path`;
+        expectTypeOf(routes["myapp://path"].get()).toEqualTypeOf<ExpectedType1>();
+
+        type ExpectedType2 = `myapp://path/${string}`;
+        const options1 = { params: { param: "value" } };
+        expectTypeOf(routes["myapp://path/[param]"].get(options1)).toEqualTypeOf<ExpectedType2>();
+
+        const options2 = { params: { params: ["value1", "value2"] } };
+        expectTypeOf(routes["myapp://path/[...params]"].get(options2)).toEqualTypeOf<ExpectedType2>();
+        expectTypeOf(routes["myapp://path/[[...params]]"].get(options2)).toEqualTypeOf<ExpectedType2>();
+
+        const options3 = { params: { param: "value" } } as const;
+        type ExpectedType3 = `myapp://path/value`;
+        expectTypeOf(routes["myapp://path/[param]"].get(options3)).toEqualTypeOf<ExpectedType3>();
+
+        const options4 = { params: { params: ["value1", "value2"] } } as const;
+        type ExpectedType4 = `myapp://path/value1/value2`;
+        expectTypeOf(routes["myapp://path/[...params]"].get(options4)).toEqualTypeOf<ExpectedType4>();
+        expectTypeOf(routes["myapp://path/[[...params]]"].get(options4)).toEqualTypeOf<ExpectedType4>();
+      });
+
+      it("Custom Schema を含んで mock 関数も戻り値が詳細に推論されること", () => {
+        type ExpectedType1 = `myapp://path`;
+        expectTypeOf(routes["myapp://path"].mock()).toEqualTypeOf<ExpectedType1>();
+        expectTypeOf(routes["myapp://path"].get.mock()).toEqualTypeOf<ExpectedType1>();
+
+        type ExpectedType2 = `myapp://path/*`;
+        expectTypeOf(routes["myapp://path/[param]"].mock()).toEqualTypeOf<ExpectedType2>();
+        expectTypeOf(routes["myapp://path/[param]"].get.mock()).toEqualTypeOf<ExpectedType2>();
+        expectTypeOf(routes["myapp://path/[...params]"].mock()).toEqualTypeOf<ExpectedType2>();
+        expectTypeOf(routes["myapp://path/[...params]"].get.mock()).toEqualTypeOf<ExpectedType2>();
+        expectTypeOf(routes["myapp://path/[[...params]]"].mock()).toEqualTypeOf<ExpectedType2>();
+        expectTypeOf(routes["myapp://path/[[...params]]"].get.mock()).toEqualTypeOf<ExpectedType2>();
+
+        const options1 = { params: { param: "value" } };
+        type ExpectedType3 = `myapp://path/${string}`;
+        expectTypeOf(routes["myapp://path/[param]"].mock(options1)).toEqualTypeOf<ExpectedType3>();
+        expectTypeOf(routes["myapp://path/[param]"].get.mock(options1)).toEqualTypeOf<ExpectedType3>();
+
+        const options2 = { params: { params: ["value1", "value2"] } };
+        expectTypeOf(routes["myapp://path/[...params]"].mock(options2)).toEqualTypeOf<ExpectedType3>();
+        expectTypeOf(routes["myapp://path/[...params]"].get.mock(options2)).toEqualTypeOf<ExpectedType3>();
+        expectTypeOf(routes["myapp://path/[[...params]]"].mock(options2)).toEqualTypeOf<ExpectedType3>();
+        expectTypeOf(routes["myapp://path/[[...params]]"].get.mock(options2)).toEqualTypeOf<ExpectedType3>();
+
+        const options3 = { params: { param: "value" } } as const;
+        type ExpectedType4 = `myapp://path/value`;
+        expectTypeOf(routes["myapp://path/[param]"].mock(options3)).toEqualTypeOf<ExpectedType4>();
+        expectTypeOf(routes["myapp://path/[param]"].get.mock(options3)).toEqualTypeOf<ExpectedType4>();
+
+        const options4 = { params: { params: ["value1", "value2"] } } as const;
+        type ExpectedType5 = `myapp://path/value1/value2`;
+        expectTypeOf(routes["myapp://path/[...params]"].mock(options4)).toEqualTypeOf<ExpectedType5>();
+        expectTypeOf(routes["myapp://path/[[...params]]"].mock(options4)).toEqualTypeOf<ExpectedType5>();
+      });
+
+      it("2重スキーマが含まれる場合も戻り値が推論されること", () => {
+        const options1 = { params: { param: "1" } } as const;
+        type ExpectedType1 = `myapp://https://example.com/1`;
+        expectTypeOf(routes["myapp://https://example.com/[param]"].get(options1)).toEqualTypeOf<ExpectedType1>();
+
+        const options2 = { params: { params: ["1", "2"], param: "3" } } as const;
+        type ExpectedType2 = `myapp://path/1/2/https://example.com/3`;
+        expectTypeOf(
+          routes["myapp://path/[[...params]]/https://example.com/[param]"].get(options2),
+        ).toEqualTypeOf<ExpectedType2>();
       });
     });
   });

--- a/src/definitions.test.ts
+++ b/src/definitions.test.ts
@@ -70,7 +70,7 @@ describe("routes", () => {
     },
     "/hash": {
       get: {
-        hash: schema.type as string,
+        hash: schema.type as "section" | "hash with space",
       },
     },
     "/all/[param]": {
@@ -81,7 +81,7 @@ describe("routes", () => {
         queries: {
           optional: schema.type as string | undefined,
         },
-        hash: schema.type as string,
+        hash: schema.type as "hash",
       },
     },
     "/short/empty": schema.empty,
@@ -92,7 +92,7 @@ describe("routes", () => {
       queries: {
         required: schema.type as string,
       },
-      hash: schema.type as string,
+      hash: schema.type as "hash",
     },
     "/short/all/[[...params]]": {
       params: {
@@ -101,7 +101,30 @@ describe("routes", () => {
       queries: {
         optional: schema.type as string | undefined,
       },
-      hash: schema.type as string,
+      hash: schema.type as "hash",
+    },
+
+    "/mock/[param]": {
+      get: {
+        params: {
+          param: schema.type as string,
+        },
+        queries: {
+          str: schema.type as string,
+          both: schema.type as string,
+        },
+        hash: "hash1",
+      },
+      post: {
+        params: {
+          param: schema.type as number,
+        },
+        queries: {
+          num: schema.type as number,
+          both: schema.type as number,
+        },
+        hash: "hash2",
+      },
     },
   });
 
@@ -109,6 +132,8 @@ describe("routes", () => {
     expect(routes).toHaveProperty("/methods");
     expect(routes).toHaveProperty("/params/[param]");
     expect(routes).toHaveProperty("/params/[param1]/[param2]");
+    expect(routes).toHaveProperty("/params/[...params]");
+    expect(routes).toHaveProperty("/params/[[...params]]");
     expect(routes).toHaveProperty("/queries/required");
     expect(routes).toHaveProperty("/queries/both");
     expect(routes).toHaveProperty("/queries/optional");
@@ -118,6 +143,8 @@ describe("routes", () => {
     expect(routes).toHaveProperty("/short/empty");
     expect(routes).toHaveProperty("/short/all/[param]");
     expect(routes).toHaveProperty("/short/all/[[...params]]");
+
+    expect(routes).toHaveProperty("/mock/[param]");
   });
 
   it("各エンドポイントに対応するすべての HTTP メソッドが生成されること", () => {
@@ -128,6 +155,8 @@ describe("routes", () => {
 
     expect(routes["/params/[param]"].get).toBeInstanceOf(Function);
     expect(routes["/params/[param1]/[param2]"].get).toBeInstanceOf(Function);
+    expect(routes["/params/[...params]"].get).toBeInstanceOf(Function);
+    expect(routes["/params/[[...params]]"].get).toBeInstanceOf(Function);
     expect(routes["/queries/required"].get).toBeInstanceOf(Function);
     expect(routes["/queries/both"].get).toBeInstanceOf(Function);
     expect(routes["/queries/optional"].get).toBeInstanceOf(Function);
@@ -137,6 +166,46 @@ describe("routes", () => {
     expect(routes["/short/empty"].get).toBeInstanceOf(Function);
     expect(routes["/short/all/[param]"].get).toBeInstanceOf(Function);
     expect(routes["/short/all/[[...params]]"].get).toBeInstanceOf(Function);
+
+    expect(routes["/mock/[param]"].get).toBeInstanceOf(Function);
+    expect(routes["/mock/[param]"].post).toBeInstanceOf(Function);
+  });
+
+  it("各エンドポイントと HTTP メソッドには mock 関数が生成されること", () => {
+    expect(routes["/methods"].mock).toBeInstanceOf(Function);
+    expect(routes["/methods"].get.mock).toBeInstanceOf(Function);
+    expect(routes["/methods"].post.mock).toBeInstanceOf(Function);
+    expect(routes["/methods"].put.mock).toBeInstanceOf(Function);
+    expect(routes["/methods"].delete.mock).toBeInstanceOf(Function);
+
+    expect(routes["/params/[param]"].mock).toBeInstanceOf(Function);
+    expect(routes["/params/[param]"].get.mock).toBeInstanceOf(Function);
+    expect(routes["/params/[param1]/[param2]"].mock).toBeInstanceOf(Function);
+    expect(routes["/params/[param1]/[param2]"].get.mock).toBeInstanceOf(Function);
+    expect(routes["/params/[...params]"].mock).toBeInstanceOf(Function);
+    expect(routes["/params/[...params]"].get.mock).toBeInstanceOf(Function);
+    expect(routes["/params/[[...params]]"].mock).toBeInstanceOf(Function);
+    expect(routes["/params/[[...params]]"].get.mock).toBeInstanceOf(Function);
+
+    expect(routes["/queries/required"].mock).toBeInstanceOf(Function);
+    expect(routes["/queries/required"].get.mock).toBeInstanceOf(Function);
+    expect(routes["/queries/both"].mock).toBeInstanceOf(Function);
+    expect(routes["/queries/both"].get.mock).toBeInstanceOf(Function);
+    expect(routes["/queries/optional"].mock).toBeInstanceOf(Function);
+    expect(routes["/queries/optional"].get.mock).toBeInstanceOf(Function);
+
+    expect(routes["/hash"].mock).toBeInstanceOf(Function);
+    expect(routes["/hash"].get.mock).toBeInstanceOf(Function);
+
+    expect(routes["/all/[param]"].mock).toBeInstanceOf(Function);
+    expect(routes["/all/[param]"].get.mock).toBeInstanceOf(Function);
+
+    expect(routes["/short/empty"].mock).toBeInstanceOf(Function);
+    expect(routes["/short/empty"].get.mock).toBeInstanceOf(Function);
+    expect(routes["/short/all/[param]"].mock).toBeInstanceOf(Function);
+    expect(routes["/short/all/[param]"].get.mock).toBeInstanceOf(Function);
+    expect(routes["/short/all/[[...params]]"].mock).toBeInstanceOf(Function);
+    expect(routes["/short/all/[[...params]]"].get.mock).toBeInstanceOf(Function);
   });
 
   describe("HTTP メソッドに必要なパラメータがない(empty で宣言されている)場合", () => {
@@ -147,49 +216,51 @@ describe("routes", () => {
 
       expect(url).toBe(expectedUrl);
     });
+
+    it("mock 関数も引数なしで URL を生成できること", () => {
+      const expectedUrl = "/methods";
+
+      const url1 = routes["/methods"].mock();
+      const url2 = routes["/methods"].get.mock();
+
+      expect(url1).toBe(expectedUrl);
+      expect(url2).toBe(expectedUrl);
+    });
   });
 
   describe("パスパラメータが宣言されている場合", () => {
     it("パスパラメータを指定して URL を生成できること", () => {
-      const expectedParams = { param: "1" };
-      const expectedUrl = `/params/${expectedParams.param}`;
+      const options = { params: { param: "1" } };
+      const expectedUrl = "/params/1";
 
-      const url = routes["/params/[param]"].get({
-        params: expectedParams,
-      });
+      const url = routes["/params/[param]"].get(options);
 
       expect(url).toBe(expectedUrl);
     });
 
     it("複数のパスパラメータを指定して URL を生成できること", () => {
-      const expectedParams = { param1: "1", param2: "2" };
-      const expectedUrl = `/params/${expectedParams.param1}/${expectedParams.param2}`;
+      const options = { params: { param1: "1", param2: "2" } };
+      const expectedUrl = "/params/1/2";
 
-      const url = routes["/params/[param1]/[param2]"].get({
-        params: expectedParams,
-      });
+      const url = routes["/params/[param1]/[param2]"].get(options);
 
       expect(url).toBe(expectedUrl);
     });
 
     it("可変長なパスパラメータを指定して URL を生成できること", () => {
-      const expectedParams = { params: ["1", "2"] };
-      const expectedUrl = `/params/${expectedParams.params.join("/")}`;
+      const options = { params: { params: ["1", "2"] } };
+      const expectedUrl = "/params/1/2";
 
-      const url = routes["/params/[...params]"].get({
-        params: expectedParams,
-      });
+      const url = routes["/params/[...params]"].get(options);
 
       expect(url).toBe(expectedUrl);
     });
 
     it("可変長でオプショナルなパスパラメータを指定して URL を生成できること", () => {
-      const expectedParams = { params: ["1", "2"] };
-      const expectedUrl = `/params/${expectedParams.params.join("/")}`;
+      const options = { params: { params: ["1", "2"] } };
+      const expectedUrl = "/params/1/2";
 
-      const url = routes["/params/[[...params]]"].get({
-        params: expectedParams,
-      });
+      const url = routes["/params/[[...params]]"].get(options);
 
       expect(url).toBe(expectedUrl);
     });
@@ -201,37 +272,69 @@ describe("routes", () => {
 
       expect(url).toBe(expectedUrl);
     });
+
+    it("mock 関数はパスパラメータを省略してワイルドカードが設定された URL を生成できること", () => {
+      const expectedUrl1 = "/params/*";
+      expect(routes["/params/[param]"].mock()).toBe(expectedUrl1);
+      expect(routes["/params/[param]"].get.mock()).toBe(expectedUrl1);
+
+      const expectedUrl2 = "/params/*/*";
+      expect(routes["/params/[param1]/[param2]"].mock()).toBe(expectedUrl2);
+      expect(routes["/params/[param1]/[param2]"].get.mock()).toBe(expectedUrl2);
+
+      expect(routes["/params/[...params]"].mock()).toBe(expectedUrl1);
+      expect(routes["/params/[...params]"].get.mock()).toBe(expectedUrl1);
+      expect(routes["/params/[[...params]]"].mock()).toBe(expectedUrl1);
+      expect(routes["/params/[[...params]]"].get.mock()).toBe(expectedUrl1);
+    });
+
+    it("mock 関数は自由にパスパラメータを指定して URL を生成できること", () => {
+      const options1 = { params: { param: 123 } };
+      const expectedUrl1 = "/params/123";
+      expect(routes["/params/[param]"].mock(options1)).toBe(expectedUrl1);
+      expect(routes["/params/[param]"].get.mock(options1)).toBe(expectedUrl1);
+
+      const options2 = { params: { param1: 1, param2: 2 } };
+      const expectedUrl2 = "/params/1/2";
+      expect(routes["/params/[param1]/[param2]"].mock(options2)).toBe(expectedUrl2);
+      expect(routes["/params/[param1]/[param2]"].get.mock(options2)).toBe(expectedUrl2);
+
+      const options3 = { params: { params: [1, 2, 3] } };
+      const expectedUrl3 = "/params/1/2/3";
+      expect(routes["/params/[...params]"].mock(options3)).toBe(expectedUrl3);
+      expect(routes["/params/[...params]"].get.mock(options3)).toBe(expectedUrl3);
+      expect(routes["/params/[[...params]]"].mock(options3)).toBe(expectedUrl3);
+      expect(routes["/params/[[...params]]"].get.mock(options3)).toBe(expectedUrl3);
+    });
   });
 
   describe("クエリパラメータが宣言されている場合", () => {
     it("クエリパラメータ付きの URL を生成できること", () => {
-      const expectedPath = "/queries/required";
-      const expectedQueries = {
-        string: "string",
-        number: 1,
-        boolean: true,
-        array: ["string"],
+      const options = {
+        queries: {
+          string: "string",
+          number: 1,
+          boolean: true,
+          array: ["string"],
+        },
       };
-      const expectedUrl = `${expectedPath}?${stringifyQueries(expectedQueries)}`;
+      const expectedUrl = `/queries/required?${stringifyQueries(options.queries)}`;
 
-      const url = routes["/queries/required"].get({
-        queries: expectedQueries,
-      });
+      const url = routes["/queries/required"].get(options);
 
       expect(url).toBe(expectedUrl);
     });
 
     it("オプショナルなクエリパラメータは省略して URL を生成できること", () => {
-      const expectedPath = "/queries/both";
-      const expectedQueries = {
-        string: "string",
-        number: 1,
+      const options = {
+        queries: {
+          string: "string",
+          number: 1,
+        },
       };
-      const expectedUrl = `${expectedPath}?${stringifyQueries(expectedQueries)}`;
+      const expectedUrl = `/queries/both?${stringifyQueries(options.queries)}`;
 
-      const url = routes["/queries/both"].get({
-        queries: expectedQueries,
-      });
+      const url = routes["/queries/both"].get(options);
 
       expect(url).toBe(expectedUrl);
     });
@@ -245,41 +348,92 @@ describe("routes", () => {
     });
 
     it("エンコードされること", () => {
-      const expectedPath = "/queries/optional";
-      const expectedQueries = {
-        string: "string with space",
+      const options = {
+        queries: {
+          string: "string with space",
+        },
       };
-      const expectedUrl = `${expectedPath}?${stringifyQueries(expectedQueries)}`;
+      const expectedUrl = `/queries/optional?${stringifyQueries(options.queries)}`;
 
-      const url = routes["/queries/optional"].get({
-        queries: expectedQueries,
-      });
+      const url = routes["/queries/optional"].get(options);
 
       expect(url).toBe(expectedUrl);
+    });
+
+    it("mock 関数は常にクエリパラメータを省略して URL を生成できること", () => {
+      const expectedUrl1 = "/queries/required";
+
+      const url1 = routes["/queries/required"].mock();
+      const url2 = routes["/queries/required"].get.mock();
+
+      expect(url1).toBe(expectedUrl1);
+      expect(url2).toBe(expectedUrl1);
+
+      const expectedUrl2 = "/queries/both";
+
+      const url3 = routes["/queries/both"].mock();
+      const url4 = routes["/queries/both"].get.mock();
+
+      expect(url3).toBe(expectedUrl2);
+      expect(url4).toBe(expectedUrl2);
+
+      const expectedUrl3 = "/queries/optional";
+
+      const url5 = routes["/queries/optional"].mock();
+      const url6 = routes["/queries/optional"].get.mock();
+
+      expect(url5).toBe(expectedUrl3);
+      expect(url6).toBe(expectedUrl3);
+    });
+
+    it("mock 関数は自由にクエリパラメータを指定して URL を生成できること", () => {
+      const options = {
+        queries: {
+          string: 123,
+          number: true,
+          boolean: [1, 2, 3],
+          array: "string",
+        },
+      };
+      const expectedUrl1 = `/queries/required?${stringifyQueries(options.queries)}`;
+
+      const url1 = routes["/queries/required"].mock(options);
+      const url2 = routes["/queries/required"].get.mock(options);
+
+      expect(url1).toBe(expectedUrl1);
+      expect(url2).toBe(expectedUrl1);
+
+      const expectedUrl2 = `/queries/both?${stringifyQueries(options.queries)}`;
+
+      const url3 = routes["/queries/both"].mock(options);
+      const url4 = routes["/queries/both"].get.mock(options);
+
+      expect(url3).toBe(expectedUrl2);
+      expect(url4).toBe(expectedUrl2);
+
+      const expectedUrl3 = `/queries/optional?${stringifyQueries(options.queries)}`;
+
+      const url5 = routes["/queries/optional"].mock(options);
+      const url6 = routes["/queries/optional"].get.mock(options);
+
+      expect(url5).toBe(expectedUrl3);
+      expect(url6).toBe(expectedUrl3);
     });
   });
 
   describe("ハッシュが宣言されている場合", () => {
     it("ハッシュを指定して URL を生成できること", () => {
-      const expectedPath = "/hash";
-      const expectedHash = "hash";
-      const expectedUrl = `${expectedPath}#${expectedHash}`;
+      const expectedUrl = "/hash#section";
 
-      const url = routes["/hash"].get({
-        hash: expectedHash,
-      });
+      const url = routes["/hash"].get({ hash: "section" });
 
       expect(url).toBe(expectedUrl);
     });
 
     it("エンコードされること", () => {
-      const expectedPath = "/hash";
-      const expectedHash = "hash with space";
-      const expectedUrl = `${expectedPath}#hash%20with%20space`;
+      const expectedUrl = "/hash#hash%20with%20space";
 
-      const url = routes["/hash"].get({
-        hash: expectedHash,
-      });
+      const url = routes["/hash"].get({ hash: "hash with space" });
 
       expect(url).toBe(expectedUrl);
     });
@@ -291,34 +445,77 @@ describe("routes", () => {
 
       expect(url).toBe(expectedUrl);
     });
+
+    it("mock 関数もハッシュを省略して URL を生成できること", () => {
+      const expectedUrl = "/hash";
+
+      const url1 = routes["/hash"].mock();
+      const url2 = routes["/hash"].get.mock();
+
+      expect(url1).toBe(expectedUrl);
+      expect(url2).toBe(expectedUrl);
+    });
+
+    it("mock 関数は自由にハッシュを指定して URL を生成できること", () => {
+      const options = {
+        hash: "unknown",
+      };
+      const expectedUrl = "/hash#unknown";
+
+      const url1 = routes["/hash"].mock(options);
+      const url2 = routes["/hash"].get.mock(options);
+
+      expect(url1).toBe(expectedUrl);
+      expect(url2).toBe(expectedUrl);
+    });
   });
 
   describe("すべてのパラメータが宣言されている場合", () => {
     it("パスパラメータとクエリパラメータとハッシュを指定して URL を生成できること", () => {
-      const expectedParams = { param: "1" };
-      const expectedPath = `/all/${expectedParams.param}`;
-      const expectedQueries = { optional: "optional" };
-      const expectedHash = "hash";
-      const expectedUrl = `${expectedPath}?${stringifyQueries(expectedQueries)}#${expectedHash}`;
+      const options = {
+        params: { param: "1" },
+        queries: { optional: "optional" },
+        hash: "hash" as const,
+      };
+      const expectedUrl = `/all/1?${stringifyQueries(options.queries)}#hash`;
 
-      const url = routes["/all/[param]"].get({
-        params: expectedParams,
-        queries: expectedQueries,
-        hash: expectedHash,
-      });
+      const url = routes["/all/[param]"].get(options);
 
       expect(url).toBe(expectedUrl);
     });
 
     it("オプショナルなパラメータは指定なしで URL を生成できること", () => {
-      const expectedParams = { param: "1" };
-      const expectedUrl = `/all/${expectedParams.param}`;
+      const options = { params: { param: "1" } };
+      const expectedUrl = "/all/1";
 
-      const url = routes["/all/[param]"].get({
-        params: expectedParams,
-      });
+      const url = routes["/all/[param]"].get(options);
 
       expect(url).toBe(expectedUrl);
+    });
+
+    it("mock 関数はすべてのパラメータを省略して URL を生成できること", () => {
+      const expectedUrl = "/all/*";
+
+      const url1 = routes["/all/[param]"].mock();
+      const url2 = routes["/all/[param]"].get.mock();
+
+      expect(url1).toBe(expectedUrl);
+      expect(url2).toBe(expectedUrl);
+    });
+
+    it("mock 関数はすべてのパラメータを自由に指定して URL を生成できること", () => {
+      const options = {
+        params: { param: 123 },
+        queries: { optional: true },
+        hash: "unknown",
+      };
+      const expectedUrl = `/all/123?${stringifyQueries(options.queries)}#unknown`;
+
+      const url1 = routes["/all/[param]"].mock(options);
+      const url2 = routes["/all/[param]"].get.mock(options);
+
+      expect(url1).toBe(expectedUrl);
+      expect(url2).toBe(expectedUrl);
     });
   });
 
@@ -331,18 +528,25 @@ describe("routes", () => {
       expect(url).toBe(expectedUrl);
     });
 
-    it("すべてのパラメータを指定して URL を生成できること", () => {
-      const expectedParams = { param: "1" };
-      const expectedPath = `/short/all/${expectedParams.param}`;
-      const expectedQueries = { required: "required" };
-      const expectedHash = "hash";
-      const expectedUrl = `${expectedPath}?${stringifyQueries(expectedQueries)}#${expectedHash}`;
+    it("mock 関数も引数なしで URL を生成できること", () => {
+      const expectedUrl = "/short/empty";
 
-      const url = routes["/short/all/[param]"].get({
-        params: expectedParams,
-        queries: expectedQueries,
-        hash: expectedHash,
-      });
+      const url1 = routes["/short/empty"].mock();
+      const url2 = routes["/short/empty"].get.mock();
+
+      expect(url1).toBe(expectedUrl);
+      expect(url2).toBe(expectedUrl);
+    });
+
+    it("すべてのパラメータを指定して URL を生成できること", () => {
+      const options = {
+        params: { param: "1" },
+        queries: { required: "required" },
+        hash: "hash" as const,
+      };
+      const expectedUrl = `/short/all/1?${stringifyQueries(options.queries)}#hash`;
+
+      const url = routes["/short/all/[param]"].get(options);
 
       expect(url).toBe(expectedUrl);
     });
@@ -353,6 +557,48 @@ describe("routes", () => {
       const url = routes["/short/all/[[...params]]"].get();
 
       expect(url).toBe(expectedUrl);
+    });
+
+    it("mock 関数はすべてのパラメータを省略して URL を生成できること", () => {
+      const expectedUrl = "/short/all/*";
+
+      const url1 = routes["/short/all/[param]"].mock();
+      const url2 = routes["/short/all/[param]"].get.mock();
+      const url3 = routes["/short/all/[[...params]]"].mock();
+      const url4 = routes["/short/all/[[...params]]"].get.mock();
+
+      expect(url1).toBe(expectedUrl);
+      expect(url2).toBe(expectedUrl);
+      expect(url3).toBe(expectedUrl);
+      expect(url4).toBe(expectedUrl);
+    });
+
+    it("mock 関数はすべてのパラメータを自由に指定して URL を生成できること", () => {
+      const options1 = {
+        params: { param: 123 },
+        queries: { required: 123 },
+        hash: "unknown",
+      };
+      const expectedUrl1 = `/short/all/123?${stringifyQueries(options1.queries)}#unknown`;
+
+      const url1 = routes["/short/all/[param]"].mock(options1);
+      const url2 = routes["/short/all/[param]"].get.mock(options1);
+
+      expect(url1).toBe(expectedUrl1);
+      expect(url2).toBe(expectedUrl1);
+
+      const options2 = {
+        params: { params: [1, 2, 3] },
+        queries: { optional: 123 },
+        hash: "unknown",
+      };
+      const expectedUrl2 = `/short/all/1/2/3?${stringifyQueries(options2.queries)}#unknown`;
+
+      const url3 = routes["/short/all/[[...params]]"].mock(options2);
+      const url4 = routes["/short/all/[[...params]]"].get.mock(options2);
+
+      expect(url3).toBe(expectedUrl2);
+      expect(url4).toBe(expectedUrl2);
     });
   });
 });
@@ -374,18 +620,39 @@ describe("routes: baseUrl", () => {
   });
 
   it("baseUrl がついた URL を生成できること", () => {
-    const expectedParams = { param: "1" };
-    const expectedQueries = { q: "query" };
-    const expectedHash = "hash";
-    const expectedUrl = `${baseUrl}/path/${expectedParams.param}?${stringifyQueries(expectedQueries)}#${expectedHash}`;
+    const options = {
+      params: { param: "1" },
+      queries: { q: "query" },
+      hash: "hash",
+    };
+    const expectedUrl = `${baseUrl}/path/1?${stringifyQueries(options.queries)}#hash`;
 
-    const url = routes["/path/[param]"].get({
-      params: expectedParams,
-      queries: expectedQueries,
-      hash: expectedHash,
-    });
+    const url = routes["/path/[param]"].get(options);
 
     expect(url).toBe(expectedUrl);
+  });
+
+  it("mock 関数も baseUrl がついた URL を生成できること", () => {
+    const expectedUrl1 = `${baseUrl}/path/*`;
+
+    const url1 = routes["/path/[param]"].mock();
+    const url2 = routes["/path/[param]"].get.mock();
+
+    expect(url1).toBe(expectedUrl1);
+    expect(url2).toBe(expectedUrl1);
+
+    const options = {
+      params: { param: 123 },
+      queries: { q: 456 },
+      hash: "hash",
+    };
+    const expectedUrl2 = `${baseUrl}/path/123?${stringifyQueries(options.queries)}#hash`;
+
+    const url3 = routes["/path/[param]"].mock(options);
+    const url4 = routes["/path/[param]"].get.mock(options);
+
+    expect(url3).toBe(expectedUrl2);
+    expect(url4).toBe(expectedUrl2);
   });
 });
 
@@ -408,6 +675,11 @@ describe("routes: custom scheme", () => {
           params: schema.type as string[],
         },
       },
+      "schema://https://example.com/path/[param]": {
+        params: {
+          param: schema.type as string,
+        },
+      },
     });
 
     it("スラッシュが変わらずに URL を生成できること", () => {
@@ -419,34 +691,28 @@ describe("routes: custom scheme", () => {
     });
 
     it("パラメータがあってもスラッシュが変わらずに URL を生成できること", () => {
-      const expectedParams = { param: "1" };
-      const expectedUrl = `schema://params/${expectedParams.param}`;
+      const options = { params: { param: "1" } };
+      const expectedUrl = "schema://params/1";
 
-      const url = routes["schema://params/[param]"].get({
-        params: expectedParams,
-      });
+      const url = routes["schema://params/[param]"].get(options);
 
       expect(url).toBe(expectedUrl);
     });
 
     it("可変長パラメータがあってもスラッシュが変わらずに URL を生成できること", () => {
-      const expectedParams = { params: ["1", "2"] };
-      const expectedUrl = `schema://params/${expectedParams.params.join("/")}`;
+      const options = { params: { params: ["1", "2"] } };
+      const expectedUrl = "schema://params/1/2";
 
-      const url = routes["schema://params/[...params]"].get({
-        params: expectedParams,
-      });
+      const url = routes["schema://params/[...params]"].get(options);
 
       expect(url).toBe(expectedUrl);
     });
 
     it("可変長でオプショナルなパラメータがあってもスラッシュが変わらずに URL を生成できること", () => {
-      const expectedParams = { params: ["1", "2"] };
-      const expectedUrl = `schema://params/${expectedParams.params.join("/")}`;
+      const options = { params: { params: ["1", "2"] } };
+      const expectedUrl = "schema://params/1/2";
 
-      const url = routes["schema://params/[[...params]]"].get({
-        params: expectedParams,
-      });
+      const url = routes["schema://params/[[...params]]"].get(options);
 
       expect(url).toBe(expectedUrl);
     });
@@ -455,6 +721,41 @@ describe("routes: custom scheme", () => {
       const expectedUrl = "schema://params";
 
       const url = routes["schema://params/[[...params]]"].get();
+
+      expect(url).toBe(expectedUrl);
+    });
+
+    it("mock 関数もスラッシュが変わらずに URL を生成できること", () => {
+      const expectedUrl1 = "schema://empty";
+
+      const url1 = routes["schema://empty"].mock();
+      const url2 = routes["schema://empty"].get.mock();
+
+      expect(url1).toBe(expectedUrl1);
+      expect(url2).toBe(expectedUrl1);
+
+      const expectedUrl2 = "schema://params/*";
+
+      const url3 = routes["schema://params/[param]"].mock();
+      const url4 = routes["schema://params/[param]"].get.mock();
+      const url5 = routes["schema://params/[...params]"].mock();
+      const url6 = routes["schema://params/[...params]"].get.mock();
+      const url7 = routes["schema://params/[[...params]]"].mock();
+      const url8 = routes["schema://params/[[...params]]"].get.mock();
+
+      expect(url3).toBe(expectedUrl2);
+      expect(url4).toBe(expectedUrl2);
+      expect(url5).toBe(expectedUrl2);
+      expect(url6).toBe(expectedUrl2);
+      expect(url7).toBe(expectedUrl2);
+      expect(url8).toBe(expectedUrl2);
+    });
+
+    it("2重スキーマもスラッシュが変わらずに URL を生成できること", () => {
+      const options = { params: { param: "1" } };
+      const expectedUrl = "schema://https://example.com/path/1";
+
+      const url = routes["schema://https://example.com/path/[param]"].get(options);
 
       expect(url).toBe(expectedUrl);
     });
@@ -482,8 +783,7 @@ describe("routes: custom scheme", () => {
     });
 
     it("baseUrl があってもスラッシュが変わらずに URL を生成できること", () => {
-      const expectedPath = "empty";
-      const expectedUrl = `${baseUrl}${expectedPath}`;
+      const expectedUrl = `${baseUrl}empty`;
 
       // biome-ignore lint/complexity/useLiteralKeys:
       const url = routes["empty"].get();
@@ -516,24 +816,48 @@ describe("routes: custom scheme", () => {
     });
 
     it("可変長でオプショナルなパラメータがあってもスラッシュが変わらずに URL を生成できること", () => {
-      const expectedParams = { params: ["1", "2"] };
-      const expectedPath = `params/${expectedParams.params.join("/")}`;
-      const expectedUrl = `${baseUrl}${expectedPath}`;
+      const options = { params: { params: ["1", "2"] } };
+      const expectedUrl = `${baseUrl}params/1/2`;
 
-      const url = routes["params/[[...params]]"].get({
-        params: expectedParams,
-      });
+      const url = routes["params/[[...params]]"].get(options);
 
       expect(url).toBe(expectedUrl);
     });
 
     it("可変長でオプショナルなパラメータを省略してもスラッシュが変わらずに URL を生成できること", () => {
-      const expectedPath = "params";
-      const expectedUrl = `${baseUrl}${expectedPath}`;
+      const expectedUrl = `${baseUrl}params`;
 
       const url = routes["params/[[...params]]"].get();
 
       expect(url).toBe(expectedUrl);
+    });
+
+    it("mock 関数もスラッシュが変わらずに URL を生成できること", () => {
+      const expectedUrl1 = `${baseUrl}empty`;
+
+      // biome-ignore lint/complexity/useLiteralKeys:
+      const url1 = routes["empty"].mock();
+      // biome-ignore lint/complexity/useLiteralKeys:
+      const url2 = routes["empty"].get.mock();
+
+      expect(url1).toBe(expectedUrl1);
+      expect(url2).toBe(expectedUrl1);
+
+      const expectedUrl2 = `${baseUrl}params/*`;
+
+      const url3 = routes["params/[param]"].mock();
+      const url4 = routes["params/[param]"].get.mock();
+      const url5 = routes["params/[...params]"].mock();
+      const url6 = routes["params/[...params]"].get.mock();
+      const url7 = routes["params/[[...params]]"].mock();
+      const url8 = routes["params/[[...params]]"].get.mock();
+
+      expect(url3).toBe(expectedUrl2);
+      expect(url4).toBe(expectedUrl2);
+      expect(url5).toBe(expectedUrl2);
+      expect(url6).toBe(expectedUrl2);
+      expect(url7).toBe(expectedUrl2);
+      expect(url8).toBe(expectedUrl2);
     });
   });
 });

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,5 +1,5 @@
 import type { ActualSchema, Empty, ExpectedSchema, Options } from "./types";
-import { extractSchemaFromPath, isOptions, joinSchemaToPath, replacePathParams, stringifyQueries } from "./utilities";
+import { isOptions, replacePathParams, stringifyQueries } from "./utilities";
 
 /**
  * Utility used to define parameter types in parameter schemas
@@ -19,19 +19,22 @@ export const empty: Empty = undefined;
 
 /**
  * Higher-order function that returns a URL generator for an endpoint, given its parameters
+ *
  * @param endpoint - The endpoint path, which can include path parameters (e.g., "/users/[id]")
  * @param baseUrl - The base URL to prepend to the generated URL (optional)
+ * @param mocking - A flag indicating whether to generate a URL for mocking purposes, which allows missing parameters to be replaced with "*" (optional)
+ * @returns A function that takes an options object and returns a generated URL with path parameters replaced, query parameters appended, and hash fragment included as specified in the options.
+ *
  * @example
  * const getUrl = method("/users/[id]", "https://example.com/api");
  * getUrl({ params: { id: "1" }, queries: { flag: true } });
  * // => "https://example.com/api/users/1?flag=true"
  */
-function method(endpoint: string, baseUrl = "") {
+function method(endpoint: string, baseUrl = "", mocking = false) {
   return (options?: Options) => {
-    const { schema, pathWithoutSchema } = extractSchemaFromPath(endpoint);
-    const processedPath = replacePathParams(pathWithoutSchema, options?.params);
-    const path = joinSchemaToPath(schema, processedPath);
-    const queries = options?.queries ? `?${stringifyQueries(options.queries)}` : "";
+    const path = replacePathParams(endpoint, options?.params, mocking);
+    const queries =
+      options?.queries && Object.keys(options.queries).length > 0 ? `?${stringifyQueries(options.queries)}` : "";
     const hash = options?.hash ? `#${encodeURIComponent(options.hash)}` : "";
     return `${baseUrl}${path}${queries}${hash}`;
   };
@@ -43,10 +46,11 @@ function method(endpoint: string, baseUrl = "") {
  *
  * @param schema - The routes schema, defining endpoints, their associated HTTP methods (which can be omitted for the shorthand feature), and various options (e.g., path, query, and hash parameters).
  * @returns An object containing type-safe URL builders for each route and method.
+ *
  * @example
  * import { routes, type, empty } from "routopia";
  *
- * const routes = routes({
+ * const myRoutes = routes({
  *   // Example for the /users route
  *   "/users": {
  *     get: {
@@ -90,10 +94,11 @@ export function routes<Schema extends ExpectedSchema<Schema>>(schema: Schema): A
  * @param baseUrl - The base URL to prepend to the generated URLs.
  * @param schema - The routes schema, defining endpoints, their associated HTTP methods (which can be omitted for the shorthand feature), and various options (e.g., path, query, and hash parameters).
  * @returns An object containing type-safe URL builders for each route and method.
+ *
  * @example
  * import { routes, type, empty } from "routopia";
  *
- * const routes = routes("https://example.com/api", {
+ * const myRoutes = routes("https://example.com/api", {
  *   // Example for the /users route
  *   "/users": {
  *     get: {
@@ -141,12 +146,15 @@ export function routes<Schema extends ExpectedSchema<Schema>, BaseUrl extends st
   const schema = hasBaseUrl ? args[1] : args[0];
 
   return Object.entries<object | Empty>(schema).reduce((acc, [endpoint, methodsOrOptions]) => {
-    const keys = methodsOrOptions && Object.keys(methodsOrOptions);
+    const generate = (mocking = false) => method(endpoint, baseUrl, mocking);
+    const generatorWithMock = Object.assign(generate(), { mock: generate(true) });
 
+    const keys = methodsOrOptions && Object.keys(methodsOrOptions);
     if (!keys || keys.every(isOptions)) {
       return Object.assign(acc, {
         [endpoint]: {
-          get: method(endpoint, baseUrl),
+          mock: generate(true),
+          get: generatorWithMock,
         },
       });
     }
@@ -156,9 +164,11 @@ export function routes<Schema extends ExpectedSchema<Schema>, BaseUrl extends st
       [endpoint]: keys.reduce(
         (acc, httpMethod) =>
           Object.assign(acc, {
-            [httpMethod]: method(endpoint, baseUrl),
+            [httpMethod]: generatorWithMock,
           }),
-        {},
+        {
+          mock: generate(true),
+        },
       ),
     });
   }, {}) as ActualSchema<Schema, BaseUrl>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,9 +9,19 @@ type Nullable<T> = T | undefined;
 type HttpMethod = "get" | "post" | "put" | "delete";
 
 /**
+ * Schema type for primitive path parameter.
+ */
+export type SchemaPrimitiveParam = string | number;
+
+/**
+ * Schema type for array path parameter (catch-all segments).
+ */
+export type SchemaArrayParam = ReadonlyArray<SchemaPrimitiveParam>;
+
+/**
  * Schema type for path parameter
  */
-type SchemaParam = string | number | ReadonlyArray<string | number> | undefined;
+type SchemaParam = SchemaPrimitiveParam | SchemaArrayParam;
 
 /**
  * Schema type for path parameters
@@ -19,18 +29,19 @@ type SchemaParam = string | number | ReadonlyArray<string | number> | undefined;
 type SchemaParams = Record<string, SchemaParam>;
 
 /**
+ * Schema type for primitive query parameter.
+ */
+type SchemaPrimitiveQuery = boolean | number | string | null | bigint | undefined;
+
+/**
+ * Schema type for query parameter, which can be a primitive value or an array of primitive values.
+ */
+export type SchemaQuery = SchemaPrimitiveQuery | ReadonlyArray<SchemaPrimitiveQuery>;
+
+/**
  * Schema type of query parameters (non-object values only)
  */
-type SchemaQueries = Record<
-  string,
-  | boolean
-  | number
-  | string
-  | null
-  | bigint
-  | undefined
-  | ReadonlyArray<boolean | number | string | null | bigint | undefined>
->;
+type SchemaQueries = Record<string, SchemaQuery>;
 
 /**
  * Schema type for URL construction parameters
@@ -51,11 +62,11 @@ export type Options = { params?: SchemaParams; queries?: SchemaQueries; hash?: s
  * // { params: (string | number)[] }
  */
 type ExtractParams<Endpoint extends string> = Endpoint extends `${infer Before}[[...${infer Param}]]${infer After}`
-  ? { [K in Param]: Extract<SchemaParam, ReadonlyArray<unknown>> } & ExtractParams<Before> & ExtractParams<After>
+  ? { [K in Param]: SchemaArrayParam } & ExtractParams<Before> & ExtractParams<After>
   : Endpoint extends `${infer Before}[...${infer Param}]${infer After}`
-    ? { [K in Param]: Extract<SchemaParam, ReadonlyArray<unknown>> } & ExtractParams<Before> & ExtractParams<After>
+    ? { [K in Param]: SchemaArrayParam } & ExtractParams<Before> & ExtractParams<After>
     : Endpoint extends `${string}[${infer Param}]${infer After}`
-      ? { [K in Param]: Extract<SchemaParam, string | number> } & ExtractParams<After>
+      ? { [K in Param]: SchemaPrimitiveParam } & ExtractParams<After>
       : unknown;
 
 /**
@@ -162,18 +173,20 @@ type ReadonlyProperties<T> = {
 type EmptyObject = {};
 
 /**
- * Converts schema definition into optional keys if it has no required fields.
- * Readonly is marked to accept as const arguments.
+ * Utility type that generates the actual options type for the method based on the schema definition and endpoint string.
  * Please refer to each ActualXXXX type for more details.
  */
-type ActualOptions<Schema extends Options, Endpoint extends string> = (Schema["params"] extends Options["params"]
-  ? ActualParams<Schema["params"], Endpoint>
-  : EmptyObject) &
-  (Schema["queries"] extends Options["queries"] ? ActualQueries<Schema["queries"]> : EmptyObject) &
-  (Schema["hash"] extends Options["hash"] ? ActualHash<Schema["hash"]> : EmptyObject);
+type ActualOptions<
+  Schema extends Options,
+  Endpoint extends string,
+  Mocking = false,
+> = (Schema["params"] extends Options["params"] ? ActualParams<Schema["params"], Endpoint, Mocking> : EmptyObject) &
+  (Schema["queries"] extends Options["queries"] ? ActualQueries<Schema["queries"], Mocking> : EmptyObject) &
+  (Schema["hash"] extends Options["hash"] ? ActualHash<Schema["hash"], Mocking> : EmptyObject);
 
 /**
- * Makes path parameters deeply optional if they are optional catch-all parameters.
+ * Makes path parameters optional if they are defined as optional catch-all segments in the endpoint string.
+ * - If Mocking is true, it allows any value for path parameters.
  *
  * @example
  * ActualParams<{ param1: string; param2: string[] }, "/[param1]/[[...param2]]">
@@ -181,19 +194,33 @@ type ActualOptions<Schema extends Options, Endpoint extends string> = (Schema["p
  *
  * ActualParams<{ param: string[] }, "/[[...param]]">
  * // { params?: { param?: string[] } }
+ *
+ * ActualParams<{ param: string }, "/[param]", true>
+ * // { params?: { param?: SchemaParam } }
  */
-type ActualParams<Schema extends Options["params"], Endpoint extends string> = {
-  [K in keyof Schema as K extends OptionalCatchAllSegments<Endpoint> ? K : never]?: Readonly<Schema[K]>;
-} & {
-  [K in keyof Schema as K extends OptionalCatchAllSegments<Endpoint> ? never : K]: Readonly<Schema[K]>;
-} extends infer R
-  ? HasRequired<R> extends true
-    ? { params: R }
-    : { params?: R }
-  : never;
+type ActualParams<Schema extends Options["params"], Endpoint extends string, Mocking = false> = Mocking extends true
+  ? {
+      params?: Simplify<
+        {
+          [K in keyof Schema as K extends CatchAllSegments<Endpoint> ? K : never]?: SchemaArrayParam;
+        } & {
+          [K in keyof Schema as K extends CatchAllSegments<Endpoint> ? never : K]?: SchemaPrimitiveParam;
+        }
+      >;
+    }
+  : {
+        [K in keyof Schema as K extends OptionalCatchAllSegments<Endpoint> ? K : never]?: Readonly<Schema[K]>;
+      } & {
+        [K in keyof Schema as K extends OptionalCatchAllSegments<Endpoint> ? never : K]: Readonly<Schema[K]>;
+      } extends infer R
+    ? HasRequired<R> extends true
+      ? { params: R }
+      : { params?: R }
+    : never;
 
 /**
  * Makes query parameters deeply optional if there are no required fields.
+ * - If Mocking is true, it allows any value for queries.
  *
  * @example
  * ActualQueries<{ required: string; optional?: number }>
@@ -201,21 +228,38 @@ type ActualParams<Schema extends Options["params"], Endpoint extends string> = {
  *
  * ActualQueries<{ optional1?: string; optional2?: number }>
  * // { queries?: { optional1?: readonly string; optional2?: readonly number } }
+ *
+ * ActualQueries<{ str: string; num?: number }, true>
+ * // { queries?: { str?: SchemaQueries[string]; num?: SchemaQueries[string] } }
  */
-type ActualQueries<Schema extends Options["queries"]> = Optional<ReadonlyProperties<Schema>> extends infer R
-  ? HasRequired<R> extends true
-    ? { queries: R }
-    : { queries?: R }
+type ActualQueries<Schema extends Options["queries"], Mocking = false> = Optional<
+  ReadonlyProperties<Schema>
+> extends infer R
+  ? Mocking extends true
+    ? {
+        queries?: {
+          [K in keyof R]?: SchemaQuery;
+        };
+      }
+    : HasRequired<R> extends true
+      ? { queries: R }
+      : { queries?: R }
   : never;
 
 /**
  * Keeps hash as is, since it's always optional in the schema definition.
+ * - If Mocking is true, it allows any string value for hash.
  *
  * @example
  * ActualHash<"hash">
  * // { hash?: "hash" }
+ *
+ * ActualHash<"hash", true>
+ * // { hash?: string }
  */
-type ActualHash<Schema extends Options["hash"]> = { hash?: Schema };
+type ActualHash<Schema extends Options["hash"], Mocking = false> = Mocking extends true
+  ? { hash?: string }
+  : { hash?: Schema };
 
 /**
  * Utility type that extracts optional catch-all parameter names from an endpoint string
@@ -229,6 +273,17 @@ type OptionalCatchAllSegments<T extends string> = T extends `${string}[[...${inf
   : never;
 
 /**
+ * Utility type that extracts catch-all parameter names from an endpoint string
+ *
+ * @example
+ * CatchAllSegments<"/path/[...params]/[id]/[[...moreParams]]">
+ * // "params" | "moreParams"
+ */
+type CatchAllSegments<T extends string> = T extends `${string}[...${infer Param}]${infer After}`
+  ? Param | CatchAllSegments<After>
+  : never;
+
+/**
  * Utility type that joins an array of strings or numbers into a single string
  *
  * @example
@@ -236,15 +291,27 @@ type OptionalCatchAllSegments<T extends string> = T extends `${string}[[...${inf
  * // "123/456"
  */
 type JoinParams<T extends ReadonlyArray<unknown>> = T extends readonly [
-  infer Head extends Extract<SchemaParam, string | number>,
+  infer Head extends SchemaPrimitiveParam,
   ...infer Tail extends ReadonlyArray<unknown>,
 ]
   ? Tail["length"] extends 0
     ? Head
     : `${Head}/${JoinParams<Tail>}`
-  : T extends Extract<SchemaParam, ReadonlyArray<unknown>>
+  : T extends SchemaArrayParam
     ? T[number]
     : never;
+
+/**
+ * Utility type that trims multiple slashes from a path string,
+ * but preserves `://` separators.
+ *
+ * @example
+ * SafeTrimPath<"https://path//to//resource/">
+ * // "https://path/to/resource"
+ */
+type SafeTrimPath<Path extends string> = Path extends `${infer Before}://${infer After}`
+  ? `${TrimPath<Before>}://${SafeTrimPath<After>}`
+  : TrimPath<Path>;
 
 /**
  * Utility type that trims multiple slashes from a path string
@@ -260,7 +327,8 @@ type TrimPath<Path extends string> = Path extends `${infer Before}//${infer Afte
     : Path;
 
 /**
- * Replace [param] in path with actual values
+ * Replace [param] in path with actual values.
+ * - If Mocking is true, replace missing parameters with `*`.
  *
  * @example
  * ReplacePathParams<"/users/[userId]/posts/[postId]", { userId: "123"; postId: "456" }>
@@ -271,28 +339,38 @@ type TrimPath<Path extends string> = Path extends `${infer Before}//${infer Afte
  *
  * ReplacePathParams<"/path/[[...params]]", { params: ["123", "456"] }>
  * // "/path/123/456"
+ *
+ * ReplacePathParams<"/path/[[...params]]", {}, true>
+ * // "/path/*"
  */
 type ReplacePathParams<
   Path extends string,
   Params extends SchemaParams,
+  Mocking = false,
 > = Path extends `${infer Before}[[...${infer Param}]]${infer After}`
   ? Param extends keyof Params
-    ? Params[Param] extends Extract<SchemaParam, ReadonlyArray<unknown>>
+    ? Params[Param] extends SchemaArrayParam
       ? `${ReplacePathParams<Before, Params>}${JoinParams<Params[Param]>}${ReplacePathParams<After, Params>}`
       : never
-    : `${ReplacePathParams<Before, Params>}${ReplacePathParams<After, Params>}`
+    : Mocking extends true
+      ? `${ReplacePathParams<Before, Params>}*${ReplacePathParams<After, Params>}`
+      : `${ReplacePathParams<Before, Params>}${ReplacePathParams<After, Params>}`
   : Path extends `${infer Before}[...${infer Param}]${infer After}`
     ? Param extends keyof Params
-      ? Params[Param] extends Extract<SchemaParam, ReadonlyArray<unknown>>
+      ? Params[Param] extends SchemaArrayParam
         ? `${ReplacePathParams<Before, Params>}${JoinParams<Params[Param]>}${ReplacePathParams<After, Params>}`
         : never
-      : never
+      : Mocking extends true
+        ? `${ReplacePathParams<Before, Params>}*${ReplacePathParams<After, Params>}`
+        : never
     : Path extends `${infer Before}[${infer Param}]${infer After}`
       ? Param extends keyof Params
-        ? Params[Param] extends Extract<SchemaParam, string | number>
+        ? Params[Param] extends SchemaPrimitiveParam
           ? `${Before}${Params[Param]}${ReplacePathParams<After, Params>}`
           : never
-        : never
+        : Mocking extends true
+          ? `${Before}*${ReplacePathParams<After, Params>}`
+          : never
       : Path;
 
 /**
@@ -308,6 +386,7 @@ type ExcludeOptionalCatchAll<Path extends string> = Path extends `${infer Before
 
 /**
  * Applies path parameters if they exist
+ * - If Mocking is true, replace missing parameters with `*`.
  *
  * @example
  * ApplyParams<"/users/[userId]", { userId: 123 }>
@@ -315,14 +394,38 @@ type ExcludeOptionalCatchAll<Path extends string> = Path extends `${infer Before
  *
  * ApplyParams<"/">
  * // "/"
+ *
+ * ApplyParams<"/path/[[...params]]", {}, true>
+ * // "/path/*"
  */
-type ApplyParams<Path extends string, Params extends Nullable<Optional<ExtractParams<Path>>>> = TrimPath<
+type ApplyParams<
+  Path extends string,
+  Params extends Nullable<Optional<ExtractParams<Path>>>,
+  Mocking = false,
+> = SafeTrimPath<
   keyof Params extends never
-    ? ExcludeOptionalCatchAll<Path>
+    ? Mocking extends true
+      ? ApplyWildcard<Path>
+      : ExcludeOptionalCatchAll<Path>
     : Params extends SchemaParams
-      ? ReplacePathParams<Path, Params>
+      ? ReplacePathParams<Path, Params, Mocking>
       : never
 >;
+
+/**
+ * Replace all path parameters with `*`.
+ *
+ * @example
+ * ApplyWildcard<"/path/[...params]">
+ * // "/path/*"
+ */
+type ApplyWildcard<Path extends string> = Path extends `${infer Before}[[...${string}]]${infer After}`
+  ? `${ApplyWildcard<Before>}*${ApplyWildcard<After>}`
+  : Path extends `${infer Before}[...${string}]${infer After}`
+    ? `${ApplyWildcard<Before>}*${ApplyWildcard<After>}`
+    : Path extends `${infer Before}[${string}]${infer After}`
+      ? `${Before}*${ApplyWildcard<After>}`
+      : Path;
 
 /**
  * Applies query parameters if they exist
@@ -367,7 +470,8 @@ type ExpectedPath<
   Params extends Nullable<Optional<ExtractParams<Path>>> = undefined,
   Queries extends Nullable<SchemaQueries> = undefined,
   Hash extends Nullable<string> = undefined,
-> = ApplyHash<ApplyQueries<ApplyParams<Path, Params>, Queries>, Hash>;
+  Mocking = false,
+> = ApplyHash<ApplyQueries<ApplyParams<Path, Params, Mocking>, Queries>, Hash>;
 
 /**
  * Combines endpoint and schema definition to generate a concrete return type
@@ -383,19 +487,13 @@ type ExpectedPath<
  * ActualReturn<"/path", { queries: { q: string } }>
  * // `/path?${string}`
  */
-type ActualReturn<Endpoint extends string, Options> = Endpoint extends `${infer Schema}://${infer Path}`
-  ? `${Schema}://${ExpectedPath<
-      Path,
-      Options extends { params: infer Params extends Optional<ExtractParams<Path>> } ? Params : undefined,
-      Options extends { queries?: infer Queries extends Nullable<SchemaQueries> } ? Queries : undefined,
-      Options extends { hash: infer Hash extends string } ? Hash : undefined
-    >}`
-  : ExpectedPath<
-      Endpoint,
-      Options extends { params: infer Params extends Optional<ExtractParams<Endpoint>> } ? Params : undefined,
-      Options extends { queries?: infer Queries extends Nullable<SchemaQueries> } ? Queries : undefined,
-      Options extends { hash: infer Hash extends string } ? Hash : undefined
-    >;
+type ActualReturn<Endpoint extends string, Options, Mocking = false> = ExpectedPath<
+  Endpoint,
+  Options extends { params: infer Params extends Optional<ExtractParams<Endpoint>> } ? Params : undefined,
+  Options extends { queries?: infer Queries extends Nullable<SchemaQueries> } ? Queries : undefined,
+  Options extends { hash: infer Hash extends string } ? Hash : undefined,
+  Mocking
+>;
 
 /**
  * Alias for methods with no parameters
@@ -426,12 +524,25 @@ type Method<BaseUrl extends string, Endpoint extends string, OptionsSchema> = Op
   ? () => `${BaseUrl}${Endpoint}`
   : OptionsSchema extends Options
     ? HasRequired<ActualOptions<OptionsSchema, Endpoint>> extends true
-      ? <Options extends ActualOptions<OptionsSchema, Endpoint>>(
+      ? <Options extends Simplify<ActualOptions<OptionsSchema, Endpoint>>>(
           options: Simplify<Options>,
         ) => `${BaseUrl}${ActualReturn<Endpoint, Options>}`
-      : <Options extends ActualOptions<OptionsSchema, Endpoint>>(
+      : <Options extends Simplify<ActualOptions<OptionsSchema, Endpoint>>>(
           options?: Simplify<Options>,
         ) => `${BaseUrl}${ActualReturn<Endpoint, Options>}`
+    : never;
+
+/**
+ * Function type for mock method, which allows more flexible parameters (e.g., all optional and accepts any value) for testing purposes.
+ * - If the schema definition has no parameters, it behaves the same as the normal method.
+ * - If the schema definition has parameters, it allows all parameters to be optional and accepts any value, while still returning a correctly typed URL string.
+ */
+type MockMethod<BaseUrl extends string, Endpoint extends string, OptionsSchema> = OptionsSchema extends Empty
+  ? () => `${BaseUrl}${Endpoint}`
+  : OptionsSchema extends Options
+    ? <Options extends Simplify<ActualOptions<OptionsSchema, Endpoint, true>>>(
+        options?: Simplify<Options>,
+      ) => `${BaseUrl}${ActualReturn<Endpoint, Options, true>}`
     : never;
 
 /**
@@ -451,23 +562,92 @@ export type ExpectedSchema<Schema> = {
 };
 
 /**
+ * Utility type that adds a `mock` method to T.
+ */
+type WithMock<BaseUrl extends string, Endpoint extends string, OptionsSchema, T> = T & {
+  mock: MockMethod<BaseUrl, Endpoint, OptionsSchema>;
+};
+
+/**
+ * Extracts the value types for a specific key 'K' from all members of a union 'U'.
+ * This uses distributive conditional types to ensure that if 'K' exists in any
+ * member of the union, its type is collected into a resulting union.
+ *
+ * @example
+ * MapValues<{ a: string; b: number } | { b: string; c: boolean }, "b">
+ * // number | string
+ *
+ * MapValues<{ a: string; b: number } | { c: boolean }, "b">
+ * // number
+ */
+type MapValues<U, K> = U extends unknown ? (K extends keyof U ? U[K] : never) : never;
+
+/**
+ * Collects all possible keys from all members of a union type 'T'.
+ * Unlike 'keyof T' which only returns keys common to all members (intersection of keys),
+ * this returns the union of all keys present in any of the members.
+ *
+ * @example
+ * AllKeys<{ a: string; b: number } | { b: string; c: boolean }>
+ * // "a" | "b" | "c"
+ */
+type AllKeys<T> = T extends unknown ? keyof T : never;
+
+/**
+ * Recursively merges a union of objects into a single object structure.
+ * - If a property is an array, it preserves the array type without merging its internal elements.
+ * - If a property is an object, it recursively merges its structure.
+ * - Otherwise, it keeps the property as a union of all possible values.
+ *
+ * @example
+ * DeepMerge<{ a: string; b: number; x: { y: string } } | { b: string; c: boolean[]; x: { z: number } }>
+ * // { a: string; b: string | number; c: boolean[]; x: { y: string; z: number } }
+ */
+type DeepMerge<U> = Simplify<{
+  [K in AllKeys<U>]: MapValues<U, K> extends unknown[]
+    ? MapValues<U, K>
+    : MapValues<U, K> extends object
+      ? DeepMerge<MapValues<U, K>>
+      : MapValues<U, K>;
+}>;
+
+/**
  * Actual schema returned from the function:
  * - Each method is replaced with a typed URL generator
+ * - Each endpoint and method includes a `mock` method that allows more flexible parameters for testing purposes.
  */
 export type ActualSchema<Schema, BaseUrl extends string> = {
   [EndpointKey in keyof Schema]: EndpointKey extends string
-    ? {
-        [Key in keyof Schema[EndpointKey] as Key extends HttpMethod ? Key : never]: Method<
-          BaseUrl,
-          EndpointKey,
-          Schema[EndpointKey][Key]
-        >;
-      } & {
-        [Key in "get" as Schema[EndpointKey] extends Empty | Options ? Key : never]: Method<
-          BaseUrl,
-          EndpointKey,
-          Schema[EndpointKey]
-        >;
-      }
+    ? Schema[EndpointKey] extends Empty | Options
+      ? Simplify<
+          WithMock<
+            BaseUrl,
+            EndpointKey,
+            Schema[EndpointKey],
+            {
+              get: WithMock<
+                BaseUrl,
+                EndpointKey,
+                Schema[EndpointKey],
+                Method<BaseUrl, EndpointKey, Schema[EndpointKey]>
+              >;
+            }
+          >
+        >
+      : Simplify<
+          WithMock<
+            BaseUrl,
+            EndpointKey,
+            DeepMerge<Schema[EndpointKey][keyof Schema[EndpointKey]]>,
+            {
+              [Key in keyof Schema[EndpointKey] as Key extends HttpMethod ? Key : never]: WithMock<
+                BaseUrl,
+                EndpointKey,
+                Schema[EndpointKey][Key],
+                Method<BaseUrl, EndpointKey, Schema[EndpointKey][Key]>
+              >;
+            }
+          >
+        >
     : never;
 };

--- a/src/utilities.test.ts
+++ b/src/utilities.test.ts
@@ -1,4 +1,4 @@
-import { extractSchemaFromPath, isOptions, joinSchemaToPath, replacePathParams, stringifyQueries } from "./utilities";
+import { isOptions, replacePathParams, stringifyQueries } from "./utilities";
 
 describe("replacePathParams", () => {
   it("パスパラメータがない場合は元のパスを返すこと", () => {
@@ -43,7 +43,16 @@ describe("replacePathParams", () => {
       const path = "/path/[param]";
       const params = { param: ["1", "2"] };
 
-      expect(() => replacePathParams(path, params)).toThrowError('"param" must be not an array');
+      expect(() => replacePathParams(path, params)).toThrowError('"param" must not be an array');
+    });
+
+    it("モックモードの場合はパスパラメータが不足していてもエラーにならずワイルドカードに置換されること", () => {
+      const path = "/path/[param]";
+      const expectedPath = "/path/*";
+
+      const result = replacePathParams(path, undefined, true);
+
+      expect(result).toBe(expectedPath);
     });
   });
 
@@ -81,9 +90,18 @@ describe("replacePathParams", () => {
 
       expect(() => replacePathParams(path, params)).toThrowError('"params" is required');
     });
+
+    it("モックモードの場合はパスパラメータが不足していてもエラーにならずワイルドカードに置換されること", () => {
+      const path = "/path/[...params]";
+      const expectedPath = "/path/*";
+
+      const result = replacePathParams(path, undefined, true);
+
+      expect(result).toBe(expectedPath);
+    });
   });
 
-  describe("可変調でオプショナルなパスパラメータがある場合", () => {
+  describe("可変長でオプショナルなパスパラメータがある場合", () => {
     it("パスパラメータを置換できること", () => {
       const path = "/path/[[...params]]";
       const params = { params: ["1", "2"] };
@@ -120,6 +138,15 @@ describe("replacePathParams", () => {
 
       expect(result).toBe(expectedPath);
     });
+
+    it("モックモードの場合にパスパラメータがなければワイルドカードに置換されること", () => {
+      const path = "/path/[[...params]]";
+      const expectedPath = "/path/*";
+
+      const result = replacePathParams(path, undefined, true);
+
+      expect(result).toBe(expectedPath);
+    });
   });
 
   describe("複数のパスパラメータがある場合", () => {
@@ -138,6 +165,15 @@ describe("replacePathParams", () => {
       const params = { params: ["2", "3"] };
 
       expect(() => replacePathParams(path, params)).toThrowError('"param" is required');
+    });
+
+    it("モックモードの場合はパスパラメータが不足していてもエラーにならずワイルドカードに置換されること", () => {
+      const path = "/path/[param]/[[...params]]";
+      const expectedPath = "/path/*/*";
+
+      const result = replacePathParams(path, undefined, true);
+
+      expect(result).toBe(expectedPath);
     });
   });
 
@@ -229,47 +265,5 @@ describe("isOptions", () => {
     expect(isOptions("post")).toBe(false);
     expect(isOptions("put")).toBe(false);
     expect(isOptions("delete")).toBe(false);
-  });
-});
-
-describe("extractSchemaFromPath", () => {
-  it("スキーマが含まれていない場合、元のパスを返すこと", () => {
-    const target = "/path/to/resource";
-    const expected = { pathWithoutSchema: "/path/to/resource" };
-
-    const result = extractSchemaFromPath(target);
-
-    expect(result).toEqual(expected);
-  });
-
-  it("スキーマが含まれている場合、スキーマとパスを分離して返すこと", () => {
-    const target = "schema://path/to/resource";
-    const expected = { schema: "schema", pathWithoutSchema: "path/to/resource" };
-
-    const result = extractSchemaFromPath(target);
-
-    expect(result).toEqual(expected);
-  });
-});
-
-describe("joinSchemaToPath", () => {
-  it("スキーマがない場合、元のパスを返すこと", () => {
-    const schema = undefined;
-    const path = "/path/to/resource";
-    const expected = "/path/to/resource";
-
-    const result = joinSchemaToPath(schema, path);
-
-    expect(result).toBe(expected);
-  });
-
-  it("スキーマがある場合、スキーマとパスを結合して返すこと", () => {
-    const schema = "schema";
-    const path = "path/to/resource";
-    const expected = "schema://path/to/resource";
-
-    const result = joinSchemaToPath(schema, path);
-
-    expect(result).toBe(expected);
   });
 });

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -5,6 +5,7 @@ import type { Options } from "./types";
  *
  * @param path - The endpoint path, which can include path parameters. (e.g., "/users/[id]")
  * @param params - An object containing the values for the path parameters. (e.g., { id: "1" })
+ * @param mocking - A boolean indicating whether to allow missing parameters for mocking purposes. If true, missing parameters will be replaced with "*".
  *
  * @throws Error - Will throw an error if a required parameter is missing or if the parameter type is incorrect.
  * @returns The path with encoded path parameters replaced with actual values. (e.g., "/users/1")
@@ -16,34 +17,32 @@ import type { Options } from "./types";
  * replacePathParams("/posts/[[...slug]]", { slug: ["hoge", "fuga"] });
  * // => "/posts/hoge/fuga"
  */
-export function replacePathParams(path: string, params: Options["params"]): string {
-  const realPath = path
-    .split("/")
-    .map((segment) =>
-      segment
-        .replace(/^\[\[\.\.\.(.+)]]$/, (_, key) => {
-          if (!params?.[key]) return "";
-          const values = params[key];
-          if (!Array.isArray(values)) throw new Error(`"${key}" must be an array`);
-          return values.map(encodeURIComponent).join("/");
-        })
-        .replace(/^\[\.\.\.(.+)]$/, (_, key) => {
-          if (!params?.[key]) throw new Error(`"${key}" is required`);
-          const values = params[key];
-          if (!Array.isArray(values)) throw new Error(`"${key}" must be an array`);
-          return values.map(encodeURIComponent).join("/");
-        })
-        .replace(/^\[(.+)]$/, (_, key) => {
-          if (!params?.[key]) throw new Error(`"${key}" is required`);
-          const value = params[key];
-          if (Array.isArray(value)) throw new Error(`"${key}" must be not an array`);
-          return encodeURIComponent(String(value));
-        }),
-    )
-    .filter((segment) => segment !== "")
-    .join("/");
-
-  return path.startsWith("/") ? `/${realPath}` : realPath;
+export function replacePathParams(path: string, params: Options["params"], mocking = false): string {
+  return path
+    .replace(/\/\[\[\.\.\.(.+?)]]/g, (_, key) => {
+      // 1. /[[...slug]] - Optional Catch-all Parameters
+      const values = params?.[key];
+      if (mocking && values === undefined) return "/*";
+      if (values === undefined) return "";
+      if (!Array.isArray(values)) throw new Error(`"${key}" must be an array`);
+      return `/${values.map(encodeURIComponent).join("/")}`;
+    })
+    .replace(/\[\.\.\.(.+?)]/g, (_, key) => {
+      // 2. [...slug] - Catch-all Parameters
+      const values = params?.[key];
+      if (mocking && values === undefined) return "*";
+      if (values === undefined) throw new Error(`"${key}" is required`);
+      if (!Array.isArray(values)) throw new Error(`"${key}" must be an array`);
+      return values.map(encodeURIComponent).join("/");
+    })
+    .replace(/\[(.+?)]/g, (_, key) => {
+      // 3. [slug] - Path Parameter
+      const value = params?.[key];
+      if (mocking && value === undefined) return "*";
+      if (value === undefined) throw new Error(`"${key}" is required`);
+      if (Array.isArray(value)) throw new Error(`"${key}" must not be an array`);
+      return encodeURIComponent(String(value));
+    });
 }
 
 /**
@@ -78,37 +77,4 @@ export function stringifyQueries(queries: Options["queries"]): string {
 export function isOptions(key: string): key is keyof Options {
   const optionsKeys: (keyof Options)[] = ["params", "queries", "hash"];
   return optionsKeys.includes(key as (typeof optionsKeys)[number]);
-}
-
-const schemaSeparator = "://";
-
-/**
- * Extracts the schema from a given path if present.
- *
- * @param target - The target path which may include a schema (e.g., "schema://path/to/resource").
- * @returns An object containing the extracted schema (if any) and the remaining path.
- */
-export function extractSchemaFromPath(target: string): {
-  schema?: string;
-  pathWithoutSchema: string;
-} {
-  if (!target.includes(schemaSeparator)) return { pathWithoutSchema: target };
-
-  const [schema, path] = target.split(schemaSeparator);
-  return {
-    schema,
-    pathWithoutSchema: path,
-  };
-}
-
-/**
- * Joins the schema and path back together.
- *
- * @param schema - The schema to prepend.
- * @param path - The path to append.
- * @returns The combined schema and path by `://` separator.
- */
-export function joinSchemaToPath(schema: ReturnType<typeof extractSchemaFromPath>["schema"], path: string) {
-  if (!schema) return path;
-  return `${schema}${schemaSeparator}${path}`;
 }


### PR DESCRIPTION
## 経緯

#9 

## 要約

- `.mock()` 関数追加
- 空オブジェクトのときクエリの `?` がつかないように修正
- URL パス構築を正規表現方式に変更し、2重スキーマ等エッジケースを安全に処理できるように最適化
- テストケースの拡充
