### PR TITLE
fix: スペースがパーセントエンコーディングされるように

### DIFF
--- a/.changeset/fix-query-space-encoding.md
+++ b/.changeset/fix-query-space-encoding.md
@@ -1,0 +1,5 @@
+---
+"routopia": patch
+---
+
+Fixed an issue where spaces in query parameters were encoded as `+` instead of `%20` to comply with RFC 3986.

--- a/src/definitions.test.ts
+++ b/src/definitions.test.ts
@@ -380,7 +380,7 @@ describe("routes", () => {
           string: "string with space",
         },
       };
-      const expectedUrl = "/queries/optional?string=string+with+space";
+      const expectedUrl = "/queries/optional?string=string%20with%20space";
 
       const url = routes["/queries/optional"].get(options);
 

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -77,7 +77,7 @@ export function stringifyQueries(queries: Options["queries"], mocking = false): 
     return `?${queryString}`;
   }
 
-  const searchParams = new URLSearchParams(entries).toString();
+  const searchParams = new URLSearchParams(entries).toString().replace(/\+/g, "%20");
   return `?${searchParams}`;
 }
 


### PR DESCRIPTION
## 経緯

https://zenn.dev/link/comments/8b1138fe0d6064

## 概要

スペースのエンコード方式を `+` → `%20` に変更(戻す)
他の OSS 等を調べるとどうやら文字列置換が一般的な対応方法っぽい