### PR TITLE
fix: 虚無値はクエリから無視するように

### DIFF
--- a/.changeset/fix-query-string-filtering.md
+++ b/.changeset/fix-query-string-filtering.md
@@ -1,0 +1,5 @@
+---
+"routopia": patch
+---
+
+Fixed an issue where `null`, `undefined`, or empty arrays in query parameters were incorrectly included in the generated query string. They are now properly excluded.

--- a/src/utilities.test.ts
+++ b/src/utilities.test.ts
@@ -1,3 +1,4 @@
+import { expect } from "vitest";
 import { isOptions, replacePathParams, stringifyHash, stringifyQueries } from "./utilities";
 
 describe("replacePathParams", () => {
@@ -245,7 +246,14 @@ describe("replacePathParams", () => {
 });
 
 describe("stringifyQueries", () => {
-  it.each([undefined, {}])("クエリパラメータがない場合は空文字を返すこと", (queries) => {
+  it.each([
+    undefined,
+    {},
+    { undefined: undefined },
+    { null: null },
+    { array: [] },
+    { undefined: undefined, null: null, array: [null, undefined] },
+  ])("クエリパラメータがない(%s の)場合は空文字を返すこと", (queries) => {
     const expectedQueryString = "";
 
     const result = stringifyQueries(queries);
@@ -258,8 +266,6 @@ describe("stringifyQueries", () => {
       [{ string: "string" }, "?string=string"],
       [{ number: 1 }, "?number=1"],
       [{ boolean: true }, "?boolean=true"],
-      [{ null: null }, "?null=null"],
-      [{ undefined: undefined }, "?undefined=undefined"],
       [{ bigint: BigInt(123) }, "?bigint=123"],
       [{ empty: "" }, "?empty="],
     ])("文字列化されたクエリが返ること", (queries, expected) => {
@@ -289,6 +295,15 @@ describe("stringifyQueries", () => {
     it("クエリパラメータの値が配列の場合、キーを繰り返して返すこと", () => {
       const queries = { array: ["1", "2", "3"] };
       const expectedQueryString = "?array=1&array=2&array=3";
+
+      const result = stringifyQueries(queries);
+
+      expect(result).toBe(expectedQueryString);
+    });
+
+    it("クエリパラメータの値が混在した配列の場合、null/undefinedを除外してキーを繰り返して返すこと", () => {
+      const queries = { array: ["a", null, "b", undefined, "c"] };
+      const expectedQueryString = "?array=a&array=b&array=c";
 
       const result = stringifyQueries(queries);
 

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -67,13 +67,19 @@ export function stringifyQueries(queries: Options["queries"], mocking = false): 
   if (!queries || Object.keys(queries).length === 0) return "";
 
   const entries = Object.entries(queries)
-    .flatMap(([key, values]) =>
-      Array.isArray(values) ? values.map((value) => [key, String(value)]) : [[key, String(values)]],
-    )
+    .flatMap(([key, value]) => {
+      if (value === null || value === undefined) return [];
+
+      if (Array.isArray(value)) return value.filter((v) => v !== null && v !== undefined).map((v) => [key, String(v)]);
+
+      return [[key, String(value)]];
+    })
     .sort(([a], [b]) => a.localeCompare(b));
 
+  if (entries.length === 0) return "";
+
   if (mocking) {
-    const queryString = entries.map(([key, value]) => `${key}=${value ?? ""}`).join("&");
+    const queryString = entries.map(([key, value]) => `${key}=${value}`).join("&");
     return `?${queryString}`;
   }
 


### PR DESCRIPTION
## 経緯

`null` や `undefined` が送信されてしまうことでサーバー側が文字列として扱ってしまう/判別できないバグがあったので直す

## 変更

以下の虚無値はキーごと送信せずに無視するように修正

- null
- undefined
- []